### PR TITLE
Change optionalModules to modules as checkout location

### DIFF
--- a/mGAP/build.gradle
+++ b/mGAP/build.gradle
@@ -5,11 +5,11 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
-    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:optionalModules:dataintegration", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiJarFile")
 	external "com.github.samtools:htsjdk:${htsjdkVersion}"
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
 
-    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:optionalModules:dataintegration", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "published", depExtension: "module")
 }


### PR DESCRIPTION
#### Rationale
Consolidate to server/modules as the preferred location for building module code 

#### Related Pull Requests
https://github.com/LabKey/trialServices/pull/17
https://github.com/LabKey/tnprc_billing/pull/55
https://github.com/LabKey/tnprc_ehr/pull/236
https://github.com/LabKey/premium/pull/187
https://github.com/LabKey/medImmuneFlow/pull/16
https://github.com/LabKey/MaxQuant/pull/24
https://github.com/LabKey/provenance/pull/21
https://github.com/LabKey/cds/pull/269
https://github.com/LabKey/evaluationContent/pull/29
https://github.com/LabKey/PanoramaPremiumModules/pull/29
https://github.com/LabKey/redcap/pull/24
https://github.com/LabKey/scrumtime/pull/57
https://github.com/LabKey/medImmune/pull/66
https://github.com/LabKey/gel/pull/195
https://github.com/LabKey/mobileAppStudy/pull/101
https://github.com/LabKey/harvest/pull/95
https://github.com/LabKey/nlp/pull/160
https://github.com/LabKey/sampleManagement/pull/264
https://github.com/LabKey/complianceActivities/pull/10
https://github.com/LabKey/nci/pull/62
https://github.com/LabKey/platform/pull/1155
https://github.com/LabKey/accounts/pull/110
https://github.com/LabKey/biologics/pull/584
https://github.com/LabKey/MacCossLabModules/pull/45
TBD

#### Changes
Update README, build.gradle