### PR TITLE
bound containerfilter

### DIFF
--- a/mGAP/src/org/labkey/mgap/mGAPModule.java
+++ b/mGAP/src/org/labkey/mgap/mGAPModule.java
@@ -120,7 +120,7 @@ public class mGAPModule extends ExtendedSimpleModule
         JSONObject ret = super.getPageContextJson(context);
 
         SimpleFilter filter = new SimpleFilter();
-        filter.addClause(ContainerFilter.CURRENT.createFilterClause(mGAPSchema.getInstance().getSchema(), FieldKey.fromString("container"), context.getContainer()));
+        filter.addClause(ContainerFilter.current(context.getContainer()).createFilterClause(mGAPSchema.getInstance().getSchema(), FieldKey.fromString("container")));
         TableSelector ts = new TableSelector(mGAPSchema.getInstance().getSchema().getTable(mGAPSchema.TABLE_VARIANT_CATALOG_RELEASES), PageFlowUtil.set("rowid", "objectid", "version", "jbrowseId", "humanJbrowseId"), filter, new Sort("-releaseDate"));
         ts.setMaxRows(1);
         ts.forEachResults(rs -> {


### PR DESCRIPTION
#### Rationale
ContainerFilter is associated with a container at construction time.
Tables are constructed in the context of a specific container/user, the CF should also be specified and fixed at construction time as well.