### PR TITLE
Add dependency on htsjdk library since it is use directly in the primeseq module

### DIFF
--- a/primeseq/build.gradle
+++ b/primeseq/build.gradle
@@ -1,6 +1,7 @@
 import org.labkey.gradle.util.BuildUtils;
 
 dependencies {
+    implementation "com.github.samtools:htsjdk:${htsjdkVersion}"
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiElements")


### PR DESCRIPTION
#### Rationale
In preparation for Gradle 7.0, we have slowly been updating dependencies that rely on the `compile` configuration (which has been deprecated for this use and will result in an error in Gradle 7.0).  This configuration leaks dependencies out of a project so other projects have not had to explicitly declare dependencies that came through `compile` transitively.  With the next gradlePlugins release, we've removed the extension of the `compile` dependency from the `external` dependency, so this leakage will be stopped.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add an explicit dependency on htsjdk for the primseq module.
