### PR TITLE
Add dependency on htsjdk library in modules the rely on it directly.

### DIFF
--- a/tcrdb/build.gradle
+++ b/tcrdb/build.gradle
@@ -7,6 +7,7 @@ dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
    external "io.repseq:repseqio:${repseqVersion}"
+   implementation "com.github.samtools:htsjdk:${htsjdkVersion}"
 
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "published", depExtension: "module")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")

--- a/variantdb/build.gradle
+++ b/variantdb/build.gradle
@@ -1,6 +1,7 @@
 import org.labkey.gradle.util.BuildUtils;
 
 dependencies {
+      implementation "com.github.samtools:htsjdk:${htsjdkVersion}"
       BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "apiJarFile")
       BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
       BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiJarFile")


### PR DESCRIPTION
#### Rationale
In preparation for Gradle 7.0, we have slowly been updating dependencies that rely on the `compile` configuration (which has been deprecated for this use and will result in an error in Gradle 7.0).  This configuration leaks dependencies out of a project so other projects have not had to explicitly declare dependencies that came through `compile` transitively.  With a future gradlePlugins release, we've removed the extension of the `compile` dependency from the `external` dependency, so this leakage will be stopped.

#### Related Pull Requests
* #42 

#### Changes
* Add an explicit dependency on htsjdk for the tcrdb and variantdb modules
