### PR TITLE
Declare api and implementation dependencies to align with code usages

### DIFF
--- a/elispot_assay/build.gradle
+++ b/elispot_assay/build.gradle
@@ -1,6 +1,7 @@
 import org.labkey.gradle.util.BuildUtils;
 
 dependencies {
+   external "org.apache.commons:commons-math3:${commonsMath3Version}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 

--- a/elispot_assay/resources/credits/jars.txt
+++ b/elispot_assay/resources/credits/jars.txt
@@ -1,0 +1,4 @@
+{table}
+Filename|Component|Version|Source|License|LabKey Dev|Purpose
+commons-math3-3.6.1.jar|Commons Math|3.6.1|{link:Apache|http://commons.apache.org/math/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}||Lightweight, self-contained mathematics and statistics components
+{table}

--- a/variantdb/build.gradle
+++ b/variantdb/build.gradle
@@ -2,6 +2,8 @@ import org.labkey.gradle.util.BuildUtils;
 
 dependencies {
       implementation "com.github.samtools:htsjdk:${htsjdkVersion}"
+      external "commons-net:commons-net:${commonsNetVersion}"
+      external "org.apache.commons:commons-math3:${commonsMath3Version}"
       BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "apiJarFile")
       BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
       BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiJarFile")

--- a/variantdb/resources/credits/jars.txt
+++ b/variantdb/resources/credits/jars.txt
@@ -1,0 +1,5 @@
+{table}
+Filename|Component|Version|Source|License|Purpose
+commons-math3-3.6.1.jar|Commons Math|3.6.1|{link:Apache|http://commons.apache.org/math/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Lightweight, self-contained mathematics and statistics components
+commons-net-3.5.jar|Commons Net|3.3|{link:Apache|http://jakarta.apache.org/commons/net/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|FTPClient used to retrieve resources from other servers (e.g., GO annotations)
+{table}


### PR DESCRIPTION
#### Rationale
It is generally best practice to explicitly declare dependencies that are used in your code rather than relying on them to come through transitively.  Though in reality the risk of these transitive dependencies disappearing is low and would be easily noticed, the declaration of proper dependencies will assure that our published `pom` files are accurate and others will not have to separately declare some dependencies that we rely on when using our jar files.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1574

#### Changes
* Update dependencies and `jars.txt`