### PR TITLE
Add missing dependencies on opencsv and httpmime 

### DIFF
--- a/GenotypeAssays/build.gradle
+++ b/GenotypeAssays/build.gradle
@@ -3,6 +3,7 @@ import org.labkey.gradle.util.BuildUtils;
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "apiJarFile")
+   implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
 
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "published", depExtension: "module")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")

--- a/elispot_assay/build.gradle
+++ b/elispot_assay/build.gradle
@@ -2,6 +2,8 @@ import org.labkey.gradle.util.BuildUtils;
 
 dependencies {
    external "org.apache.commons:commons-math3:${commonsMath3Version}"
+   implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
+
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 

--- a/mGAP/build.gradle
+++ b/mGAP/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "apiJarFile")
 	external "com.github.samtools:htsjdk:${htsjdkVersion}"
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
+    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
 
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")

--- a/primeseq/build.gradle
+++ b/primeseq/build.gradle
@@ -2,6 +2,7 @@ import org.labkey.gradle.util.BuildUtils;
 
 dependencies {
     implementation "com.github.samtools:htsjdk:${htsjdkVersion}"
+    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiElements")

--- a/tcrdb/build.gradle
+++ b/tcrdb/build.gradle
@@ -8,6 +8,7 @@ dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
    external "io.repseq:repseqio:${repseqVersion}"
    implementation "com.github.samtools:htsjdk:${htsjdkVersion}"
+   implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
 
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "published", depExtension: "module")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")

--- a/variantdb/build.gradle
+++ b/variantdb/build.gradle
@@ -4,6 +4,7 @@ dependencies {
       implementation "com.github.samtools:htsjdk:${htsjdkVersion}"
       external "commons-net:commons-net:${commonsNetVersion}"
       external "org.apache.commons:commons-math3:${commonsMath3Version}"
+      implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
       BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "apiJarFile")
       BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
       BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiJarFile")


### PR DESCRIPTION
#### Rationale
With version 1.4.0 of the labkey-client-api, we will convert the dependencies on opencsv and httpmime from api dependencies to implementation dependencies since they are not actually a part of the api for this jar file.  Since both of these dependencies are included in the api module transitively, we compromise a bit and do not include them in the `jars.txt` for each individual module.

#### Related Pull Requests
* several

#### Changes
* Add explicit dependencies where missing
