### PR TITLE
Update boolean filter to be Postgres-friendly

### DIFF
--- a/GenotypeAssays/src/org/labkey/genotypeassays/GeneticsTableCustomizer.java
+++ b/GenotypeAssays/src/org/labkey/genotypeassays/GeneticsTableCustomizer.java
@@ -70,7 +70,8 @@ public class GeneticsTableCustomizer extends AbstractTableCustomizer implements 
             ti.addColumn(newCol3);
 
             //# disabled
-            SQLFragment sql4 = new SQLFragment("(select count(*) as expr from sequenceanalysis.alignment_summary_junction j WHERE j.status = 0 AND j.analysis_id = " + ExprColumn.STR_TABLE_ALIAS + ".rowid)");
+            SQLFragment sql4 = new SQLFragment("(select count(*) as expr from sequenceanalysis.alignment_summary_junction j WHERE j.status = ? AND j.analysis_id = " + ExprColumn.STR_TABLE_ALIAS + ".rowid)");
+            sql4.add(false);
             ExprColumn newCol4 = new ExprColumn(ti, "numReadsDisabled", sql4, JdbcType.INTEGER, ti.getColumn("rowid"));
             newCol.setLabel("# Allele Calls Disabled");
             ti.addColumn(newCol4);


### PR DESCRIPTION
#### Rationale
SQLException when doing query validation on Postgres:

ERROR Table                    2020-09-24T08:07:31,614   PipelineJobRunnerUMO.1 : SQL Exception
org.postgresql.util.PSQLException: ERROR: operator does not exist: boolean = integer
  Hint: No operator matches the given name and argument type(s). You might need to add explicit type casts.
  Position: 2767

#### Changes
* Use JDBC parameter to support both Postgres and SQLServer