### PR TITLE
Add missing module dependencies and move dependencies declarations out of module.properties files

### DIFF
--- a/mGAP/build.gradle
+++ b/mGAP/build.gradle
@@ -13,4 +13,5 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "published", depExtension: "module")
 }

--- a/primeseq/build.gradle
+++ b/primeseq/build.gradle
@@ -13,4 +13,5 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:DiscvrLabKeyModules:cluster", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:DiscvrLabKeyModules:jbrowse", depProjectConfig: "published", depExtension: "module")
 }

--- a/tcrdb/build.gradle
+++ b/tcrdb/build.gradle
@@ -10,6 +10,7 @@ dependencies {
    implementation "com.github.samtools:htsjdk:${htsjdkVersion}"
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
 
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "published", depExtension: "module")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "published", depExtension: "module")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "published", depExtension: "module")


### PR DESCRIPTION
#### Rationale
If a module takes a dependency on another module's jar file, we want to also declare a dependency on the module file so when not building everything from source we'll bring in the requisite modules and their jar files to the distribution.  Only in the rare case where we depend on an API jar and also check for the existence of corresponding module will we not also include the module dependency, and in that case we would declare the dependency on the jar file using the `labkey` configuration so the jar file will get copied to the `lib` directory of the module declaring the dependency and thus be available without the module.

We have also deprecated the declaration of module dependencies in the `module.properties` file in favor of declaration in the `build.gradle` file.

#### Changes
* Add missing module dependencies
* Move module dependency declarations from `module.properties` files to `build.gradle` files
