### PR TITLE
Remove disallowed <categories> element

### DIFF
--- a/mGAP/resources/referenceStudy/datasets/datasets_manifest.xml
+++ b/mGAP/resources/referenceStudy/datasets/datasets_manifest.xml
@@ -1,12 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <datasets metaDataFile="datasets_metadata.xml" xmlns="http://labkey.org/study/xml">
-    <categories>
-        <category>Behavior</category>
-        <category>ClinPath</category>
-        <category>Colony Management</category>
-        <category>Clinical</category>
-        <category>Pathology</category>
-    </categories>
     <datasets>
         <dataset name="demographics" category="Clinical" demographicData="true" type="Standard" id="1000">
             <tags/>

--- a/mcc/resources/referenceStudy/study/datasets/datasets_manifest.xml
+++ b/mcc/resources/referenceStudy/study/datasets/datasets_manifest.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <datasets metaDataFile="datasets_metadata.xml" xmlns="http://labkey.org/study/xml">
-    <categories>
-        <category>ClinPath</category>
-        <category>Colony Management</category>
-        <category>Clinical</category>
-    </categories>
     <datasets>
         <dataset name="flags" id="5019" category="Colony Management" type="Standard">
             <tags/>


### PR DESCRIPTION
#### Rationale
The `<categories>` element in `datasets_manifest.xml` has been ignored for many years. We recently removed it from the XSD.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3062

#### Changes
* Remove `<categories>` element from `datasets_manifest.xml` files in reference studies
