### PR TITLE
Update maven repositories in preparation for Artifactory configuration change

### DIFF
--- a/primeseq/build.gradle
+++ b/primeseq/build.gradle
@@ -2,13 +2,14 @@ import org.labkey.gradle.util.BuildUtils;
 
 repositories {
     mavenCentral()
+    // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
     maven {
         url "https://clojars.org/repo"
     }
     // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
-    maven {
-        url "https://maven.scijava.org/content/groups/public"
-    }
+    //maven {
+    //    url "https://maven.scijava.org/content/groups/public"
+    //}
 }
 
 dependencies {

--- a/primeseq/build.gradle
+++ b/primeseq/build.gradle
@@ -9,10 +9,6 @@ repositories {
     maven {
         url "https://maven.scijava.org/content/groups/public"
     }
-    // Added for opencharts dependency (required by biojava)
-    maven {
-        url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-    }
 }
 
 dependencies {

--- a/primeseq/build.gradle
+++ b/primeseq/build.gradle
@@ -1,5 +1,20 @@
 import org.labkey.gradle.util.BuildUtils;
 
+repositories {
+    mavenCentral()
+    maven {
+        url "https://clojars.org/repo"
+    }
+    // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
+    maven {
+        url "https://maven.scijava.org/content/groups/public"
+    }
+    // Added for opencharts dependency (required by biojava)
+    maven {
+        url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
+    }
+}
+
 dependencies {
     implementation "com.github.samtools:htsjdk:${htsjdkVersion}"
     implementation "net.sf.opencsv:opencsv:${opencsvVersion}"

--- a/primeseq/build.gradle
+++ b/primeseq/build.gradle
@@ -6,10 +6,6 @@ repositories {
     maven {
         url "https://clojars.org/repo"
     }
-    // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
-    //maven {
-    //    url "https://maven.scijava.org/content/groups/public"
-    //}
 }
 
 dependencies {

--- a/tcrdb/build.gradle
+++ b/tcrdb/build.gradle
@@ -9,10 +9,6 @@ repositories {
    maven {
       url "https://maven.scijava.org/content/groups/public"
    }
-   // Added for opencharts dependency (required by biojava)
-   maven {
-      url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-   }
 }
 
 dependencies {

--- a/tcrdb/build.gradle
+++ b/tcrdb/build.gradle
@@ -1,5 +1,20 @@
 import org.labkey.gradle.util.BuildUtils;
 
+repositories {
+   mavenCentral()
+   maven {
+      url "https://clojars.org/repo"
+   }
+   // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
+   maven {
+      url "https://maven.scijava.org/content/groups/public"
+   }
+   // Added for opencharts dependency (required by biojava)
+   maven {
+      url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
+   }
+}
+
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:singlecell", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:DiscvrLabKeyModules:SequenceAnalysis", depProjectConfig: "apiJarFile")

--- a/tcrdb/build.gradle
+++ b/tcrdb/build.gradle
@@ -6,9 +6,6 @@ repositories {
    maven {
       url "https://clojars.org/repo"
    }
-   //maven {
-   //   url "https://maven.scijava.org/content/groups/public"
-   //}
 }
 
 dependencies {

--- a/tcrdb/build.gradle
+++ b/tcrdb/build.gradle
@@ -2,13 +2,13 @@ import org.labkey.gradle.util.BuildUtils;
 
 repositories {
    mavenCentral()
+   // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
    maven {
       url "https://clojars.org/repo"
    }
-   // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
-   maven {
-      url "https://maven.scijava.org/content/groups/public"
-   }
+   //maven {
+   //   url "https://maven.scijava.org/content/groups/public"
+   //}
 }
 
 dependencies {

--- a/variantdb/build.gradle
+++ b/variantdb/build.gradle
@@ -6,10 +6,6 @@ repositories {
       maven {
             url "https://clojars.org/repo"
       }
-      // Added for opencharts dependency (required by biojava)
-      maven {
-            url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-      }
 }
 
 dependencies {

--- a/variantdb/build.gradle
+++ b/variantdb/build.gradle
@@ -1,5 +1,17 @@
 import org.labkey.gradle.util.BuildUtils;
 
+repositories {
+      mavenCentral()
+      // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
+      maven {
+            url "https://clojars.org/repo"
+      }
+      // Added for opencharts dependency (required by biojava)
+      maven {
+            url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
+      }
+}
+
 dependencies {
       implementation "com.github.samtools:htsjdk:${htsjdkVersion}"
       external "commons-net:commons-net:${commonsNetVersion}"


### PR DESCRIPTION
#### Rationale
We plan to update our Artifactory configuration so it no longer proxies for certain remote repositories. This requires that builds that require these remote repositories declare these repositories themselves. We put mavenCentral as the first repository so it won't query our Artifactory instance when looking for external dependencies.

#### Changes
* Add mavenCentral repository
* Add maven repository for scijava to pick up some dependencies not available from mavenCentral
