### PR TITLE
Add scijava repository back to pick up clojars dependency

### DIFF
--- a/primeseq/build.gradle
+++ b/primeseq/build.gradle
@@ -6,6 +6,10 @@ repositories {
     maven {
         url "https://clojars.org/repo"
     }
+    // Added for org.clojars.chapmanb:sam (required by SequenceAnalysis)
+    maven {
+        url "https://maven.scijava.org/content/groups/public"
+    }
 }
 
 dependencies {

--- a/tcrdb/build.gradle
+++ b/tcrdb/build.gradle
@@ -6,6 +6,10 @@ repositories {
    maven {
       url "https://clojars.org/repo"
    }
+   // Added for org.clojars.chapmanb:sam (required by SequenceAnalysis)
+   maven {
+      url "https://maven.scijava.org/content/groups/public"
+   }
 }
 
 dependencies {

--- a/variantdb/build.gradle
+++ b/variantdb/build.gradle
@@ -6,6 +6,10 @@ repositories {
       maven {
             url "https://clojars.org/repo"
       }
+      // Added for org.clojars.chapmanb:sam (required by SequenceAnalysis)
+      maven {
+            url "https://maven.scijava.org/content/groups/public"
+      }
 }
 
 dependencies {


### PR DESCRIPTION
#### Rationale
We want to reduce the usage of Artifactory to a minimum, so we'll stop proxying for the gradle plugins repository and the scijava repository. 

#### Related Pull Requests
* https://github.com/LabKey/server/pull/250
* https://github.com/LabKey/DiscvrLabKeyModules/pull/141

#### Changes
* Add scijava repository
