### PR TITLE
Remove use of jboss repository that is so flaky

### DIFF
--- a/covidseq/build.gradle
+++ b/covidseq/build.gradle
@@ -6,10 +6,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    // Added for opencharts dependency (required by biojava)
-    maven {
-        url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-    }
 }
 
 dependencies {

--- a/mGAP/build.gradle
+++ b/mGAP/build.gradle
@@ -3,10 +3,6 @@ import org.labkey.gradle.util.ExternalDependency
 
 repositories {
     mavenCentral()
-    // Added for opencharts dependency (required by biojava)
-    maven {
-        url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-    }
 }
 
 dependencies {

--- a/primeseq/build.gradle
+++ b/primeseq/build.gradle
@@ -6,10 +6,6 @@ repositories {
     maven {
         url "https://clojars.org/repo"
     }
-    // Added for opencharts dependency (required by biojava)
-    maven {
-        url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-    }
 }
 
 dependencies {

--- a/tcrdb/build.gradle
+++ b/tcrdb/build.gradle
@@ -7,10 +7,6 @@ repositories {
    maven {
       url "https://clojars.org/repo"
    }
-   // Added for opencharts dependency (required by biojava)
-   maven {
-      url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-   }
 }
 
 dependencies {

--- a/variantdb/build.gradle
+++ b/variantdb/build.gradle
@@ -3,14 +3,6 @@ import org.labkey.gradle.util.ExternalDependency
 
 repositories {
       mavenCentral()
-      // Added for opencharts dependency (required by biojava)
-      maven {
-            url "https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/"
-      }
-}
-
-repositories {
-      mavenCentral()
       // Added for org.clojars.chapmanb:sam dependency required by com.github.samtools:htsjdk
       maven {
             url "https://clojars.org/repo"


### PR DESCRIPTION
#### Rationale
The jboss repository is nothing but trouble because it is quite unstable.  We seem to need only one dependency from that repository (opencharts:opencharts:1.4.2), so this has been deployed to the ext-release-local repository in our Artifactory instance. 

#### Related Pull Requests
* https://github.com/LabKey/DiscvrLabKeyModules/pull/142

#### Changes
* Remove the jboss repository in various places.