### PR TITLE
Update artifactory URL for 22.3

### DIFF
--- a/mcc/.npmrc
+++ b/mcc/.npmrc
@@ -1,1 +1,1 @@
-@labkey:registry=https://artifactory.labkey.com/artifactory/api/npm/libs-client
+@labkey:registry=https://labkey.jfrog.io/artifactory/api/npm/libs-client

--- a/mcc/package-lock.json
+++ b/mcc/package-lock.json
@@ -2440,13 +2440,13 @@
     },
     "node_modules/@labkey/api": {
       "version": "1.8.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.8.0.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.8.0.tgz",
       "integrity": "sha1-DiGjCOphC25lFsGwX3BC7kGmhlc=",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-5.0.0.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-5.0.0.tgz",
       "integrity": "sha1-b1nqEvp+G6My9Q0zBWzx4/dLAJc=",
       "dev": true,
       "license": "Apache-2.0",
@@ -15899,12 +15899,12 @@
     },
     "@labkey/api": {
       "version": "1.8.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.8.0.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.8.0.tgz",
       "integrity": "sha1-DiGjCOphC25lFsGwX3BC7kGmhlc="
     },
     "@labkey/build": {
       "version": "5.0.0",
-      "resolved": "https://artifactory.labkey.com:443/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-5.0.0.tgz",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-5.0.0.tgz",
       "integrity": "sha1-b1nqEvp+G6My9Q0zBWzx4/dLAJc=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
#### Rationale
Artifactory migration

#### Related Pull Requests
* [Server](https://github.com/LabKey/server/pull/280)

#### Changes
* Update artifactory url in package.json and package-lock.json