### PR TITLE
Issue 48499: Use preferred SecurityPolicyManager.savePolicy() variant

### DIFF
--- a/mGAP/src/org/labkey/mgap/mGAPController.java
+++ b/mGAP/src/org/labkey/mgap/mGAPController.java
@@ -434,7 +434,7 @@ public class mGAPController extends SpringActionController
                     }
                 }
 
-                SecurityPolicyManager.savePolicy(policy);
+                SecurityPolicyManager.savePolicy(policy, getUser());
 
                 transaction.commit();
             }

--- a/mcc/src/org/labkey/mcc/MccController.java
+++ b/mcc/src/org/labkey/mcc/MccController.java
@@ -572,7 +572,7 @@ public class MccController extends SpringActionController
                 {
                     MutableSecurityPolicy policy = new MutableSecurityPolicy(requestContainer.getPolicy());
                     policy.addRoleAssignment(requestGroup, RoleManager.getRole(MccRequesterRole.class));
-                    SecurityPolicyManager.savePolicy(policy);
+                    SecurityPolicyManager.savePolicy(policy, getUser());
                 }
 
                 Group reviewGroup = GroupManager.getGroup(ContainerManager.getRoot(), MccManager.REQUEST_REVIEW_GROUP_NAME, GroupEnumType.SITE);
@@ -580,7 +580,7 @@ public class MccController extends SpringActionController
                 {
                     MutableSecurityPolicy policy = new MutableSecurityPolicy(requestContainer.getPolicy());
                     policy.addRoleAssignment(reviewGroup, RoleManager.getRole(MccRabReviewerRole.class));
-                    SecurityPolicyManager.savePolicy(policy);
+                    SecurityPolicyManager.savePolicy(policy, getUser());
                 }
 
                 Group finalGroup = GroupManager.getGroup(ContainerManager.getRoot(), MccManager.FINAL_REVIEW_GROUP_NAME, GroupEnumType.SITE);
@@ -588,7 +588,7 @@ public class MccController extends SpringActionController
                 {
                     MutableSecurityPolicy policy = new MutableSecurityPolicy(requestContainer.getPolicy());
                     policy.addRoleAssignment(finalGroup, RoleManager.getRole(MccFinalReviewerRole.class));
-                    SecurityPolicyManager.savePolicy(policy);
+                    SecurityPolicyManager.savePolicy(policy, getUser());
                 }
 
                 Group adminGroup = GroupManager.getGroup(ContainerManager.getRoot(), MccManager.ADMIN_GROUP_NAME, GroupEnumType.SITE);
@@ -596,7 +596,7 @@ public class MccController extends SpringActionController
                 {
                     MutableSecurityPolicy policy = new MutableSecurityPolicy(requestContainer.getPolicy());
                     policy.addRoleAssignment(adminGroup, RoleManager.getRole(MccDataAdminRole.class));
-                    SecurityPolicyManager.savePolicy(policy);
+                    SecurityPolicyManager.savePolicy(policy, getUser());
                 }
             }
 
@@ -608,7 +608,7 @@ public class MccController extends SpringActionController
                 {
                     MutableSecurityPolicy policy = new MutableSecurityPolicy(dataContainer.getPolicy());
                     policy.addRoleAssignment(adminGroup, RoleManager.getRole(MccDataAdminRole.class));
-                    SecurityPolicyManager.savePolicy(policy);
+                    SecurityPolicyManager.savePolicy(policy, getUser());
                 }
             }
 


### PR DESCRIPTION
#### Rationale
We're uneven in terms of the validation and auditing we do for saving SecurityPolicies and related updates, and want to be more consistent.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4704

#### Changes
* Let modules register ContainerSecurableResourceProviders instead of having Container know about them all
* Remove the `savePolicy` and `createContainer` methods that don't take a user, check permissions, or log for audit purposes
* Introduce `User.getAdminServiceUser()` for `sudo` like scenarios or when we're doing an operation not initiated by a user, like bootstrapping the server
* Update callers