### PR TITLE
Fix SchemaVersionTestCase

### DIFF
--- a/IDR/module.properties
+++ b/IDR/module.properties
@@ -3,3 +3,4 @@ Label: IDR
 Description: This module will support the ONPRC IDR
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+ManageVersion: false

--- a/PMR/module.properties
+++ b/PMR/module.properties
@@ -3,3 +3,4 @@ Label: PMR
 Description: This is the ONPRC Precision Medicine Resource (PMR) module
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+ManageVersion: false


### PR DESCRIPTION
#### Rationale
`SchemaVersionTestCase` started failing because these new modules didn't specify the appropriate property