### PR TITLE
Migrate to non-deprecated method

### DIFF
--- a/mGAP/src/org/labkey/mgap/mGAPController.java
+++ b/mGAP/src/org/labkey/mgap/mGAPController.java
@@ -477,7 +477,7 @@ public class mGAPController extends SpringActionController
             Container mGapContainer = mGAPManager.get().getMGapContainer();
             for (User u : existingUsersGivenAccess)
             {
-                boolean isLDAP = AuthenticationManager.isLdapEmail(new ValidEmail(u.getEmail()));
+                boolean isLDAP = AuthenticationManager.isLdapOrSsoEmail(new ValidEmail(u.getEmail()));
 
                 MailHelper.MultipartMessage mail = MailHelper.createMultipartMessage();
                 mail.setEncodedHtmlContent("Your account request has been approved for mGAP!  " + "<a href=\"" + AppProps.getInstance().getBaseServerUrl() + mGapContainer.getStartURL(getUser()) + "\">Click here to access the site.</a>" + (isLDAP ? "  Use your normal OHSU email/password to login." : ""));

--- a/mcc/src/org/labkey/mcc/MccController.java
+++ b/mcc/src/org/labkey/mcc/MccController.java
@@ -406,7 +406,7 @@ public class MccController extends SpringActionController
             Container mccContainer = MccManager.get().getMCCContainer(getContainer());
             for (User u : existingUsersGivenAccess)
             {
-                boolean isLDAP = AuthenticationManager.isLdapEmail(new ValidEmail(u.getEmail()));
+                boolean isLDAP = AuthenticationManager.isLdapOrSsoEmail(new ValidEmail(u.getEmail()));
 
                 MailHelper.MultipartMessage mail = MailHelper.createMultipartMessage();
                 mail.setEncodedHtmlContent("Your account request has been approved for MCC!  " + "<a href=\"" + AppProps.getInstance().getBaseServerUrl() + mccContainer.getStartURL(getUser()) + "\">Click here to access the site.</a>" + (isLDAP ? "  Use your normal OHSU email/password to login." : ""));


### PR DESCRIPTION
#### Rationale
No functional change, but old method name is a misnomer