### PR TITLE
Mark modules that support both databases

### DIFF
--- a/GenotypeAssays/module.properties
+++ b/GenotypeAssays/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.genotypeassays.GenotypeAssaysModule
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/IDR/module.properties
+++ b/IDR/module.properties
@@ -4,3 +4,4 @@ Description: This module will support the ONPRC IDR
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/LabPurchasing/module.properties
+++ b/LabPurchasing/module.properties
@@ -4,3 +4,4 @@ Description: A module designed to assist with purchasing supplies for academic l
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/MccColony/module.properties
+++ b/MccColony/module.properties
@@ -3,3 +3,4 @@ Label: Module to manage MCC Colony Study Folders
 Description: This module is designed to provide views and resources specific to MCC colony folders.
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/PMR/module.properties
+++ b/PMR/module.properties
@@ -4,3 +4,4 @@ Description: This is the ONPRC Precision Medicine Resource (PMR) module
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/elispot_assay/module.properties
+++ b/elispot_assay/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.elispot_assay.ELISPOT_AssayModule
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/flowassays/module.properties
+++ b/flowassays/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.flowassays.FlowAssaysModule
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/hivrc/module.properties
+++ b/hivrc/module.properties
@@ -4,3 +4,4 @@ Description: This is designed to manage analyses and data collected as part of t
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/mGAP/module.properties
+++ b/mGAP/module.properties
@@ -2,3 +2,4 @@ ModuleClass: org.labkey.mgap.mGAPModule
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/mcc/module.properties
+++ b/mcc/module.properties
@@ -4,3 +4,4 @@ Description: This module is used by the BRAIN Initiative Maromoset Coordinating 
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/primeseq/module.properties
+++ b/primeseq/module.properties
@@ -4,3 +4,4 @@ Description: This module contains code related to our internal server, PRIMe-Seq
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/tcrdb/module.properties
+++ b/tcrdb/module.properties
@@ -4,3 +4,4 @@ Description: The TCRdb module is designed to manage TCR sequence from either clo
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 ManageVersion: false
+SupportedDatabases: mssql, pgsql


### PR DESCRIPTION
#### Rationale
Need to explicitly declare support for SQL Server since we're about to change the default to PostgreSQL-only