### PR TITLE
No need to exclude Jakarta Activation API everywhere

### DIFF
--- a/mcc/build.gradle
+++ b/mcc/build.gradle
@@ -51,10 +51,6 @@ dependencies {
                     ExternalDependency.APACHE_2_LICENSE_NAME,
                     ExternalDependency.APACHE_2_LICENSE_URL,
                     "Parsing XML Data"
-            ),
-            {
-                // Exclude in favor of angus activation from API
-                exclude group: 'jakarta.activation', module: 'jakarta.activation-api'
-            }
+            )
     )
 }


### PR DESCRIPTION
#### Rationale
Canonical version of Jakarta Activation API is now forced in `server/build.gradle`

#### Related Pull Requests
* https://github.com/LabKey/server/pull/937