### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/LabPurchasing/resources/views/manageReferenceItems.view.xml
+++ b/LabPurchasing/resources/views/manageReferenceItems.view.xml
@@ -1,8 +1,8 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Manage Reference Item">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
         <permissionClass name="org.labkey.api.security.permissions.DeletePermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="laboratory.context" />
     </dependencies>

--- a/LabPurchasing/resources/views/order.view.xml
+++ b/LabPurchasing/resources/views/order.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Order New Item(s)">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="laboratory.context" />
         <dependency path="labpurchasing/window/ReorderPreviousWindow.js"/>

--- a/LabPurchasing/resources/views/placeOrders.view.xml
+++ b/LabPurchasing/resources/views/placeOrders.view.xml
@@ -1,8 +1,8 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Order Item(s)">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
         <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="laboratory.context" />
         <dependency path="labpurchasing/window/ReorderPreviousWindow.js"/>

--- a/LabPurchasing/resources/views/populateData.view.xml
+++ b/LabPurchasing/resources/views/populateData.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Populate Purchasing Lookups and Reference Data">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="laboratory.context" />
     </dependencies>

--- a/PMR/resources/views/pmrAdmin.view.xml
+++ b/PMR/resources/views/pmrAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="PMR Site Admin">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
     </dependencies>

--- a/PMR/resources/views/pmrAnimalHistory.view.xml
+++ b/PMR/resources/views/pmrAnimalHistory.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="PMR Animal History">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
         <dependency path="ehr/panel/AnimalHistoryPanel.js"/>

--- a/PMR/resources/views/pmrOverview.view.xml
+++ b/PMR/resources/views/pmrOverview.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="PMR Overview">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
     </dependencies>

--- a/PMR/resources/views/pmrSearch.view.xml
+++ b/PMR/resources/views/pmrSearch.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="PMR Animal Search">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
     </dependencies>

--- a/mGAP/resources/views/about.view.xml
+++ b/mGAP/resources/views/about.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Citing mGAP">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mGAP/resources/views/admin.view.xml
+++ b/mGAP/resources/views/admin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mGAP/resources/views/annotation.view.xml
+++ b/mGAP/resources/views/annotation.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Variant Annotation Strategy">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mGAP/resources/views/data.view.xml
+++ b/mGAP/resources/views/data.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Sequence Data">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mGAP/resources/views/dataProcessing.view.xml
+++ b/mGAP/resources/views/dataProcessing.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Data Processing / Variant Calling Strategy">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mGAP/resources/views/demographics.view.xml
+++ b/mGAP/resources/views/demographics.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="mGAP Cohort Demographics">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mGAP/resources/views/externalData.view.xml
+++ b/mGAP/resources/views/externalData.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="mGAP Datasets and Cohorts">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mGAP/resources/views/geneSearch.view.xml
+++ b/mGAP/resources/views/geneSearch.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Gene Search">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="gen/jbrowse2SearchWebpart.lib.xml"/>
         <dependency path="LDK.context"/>

--- a/mGAP/resources/views/helpMenu.view.xml
+++ b/mGAP/resources/views/helpMenu.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Help">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
 
     </dependencies>

--- a/mGAP/resources/views/mgapDataDashboard.view.xml
+++ b/mGAP/resources/views/mgapDataDashboard.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="mGAP Data Dashboard">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
 
     </dependencies>

--- a/mGAP/resources/views/overview.view.xml
+++ b/mGAP/resources/views/overview.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="The Macaque Genotype and Phenotype Resource (mGAP)">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
         <dependency path="internal/jQuery"/>

--- a/mGAP/resources/views/phenotypeList.view.xml
+++ b/mGAP/resources/views/phenotypeList.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Diseases/Phenotypes Implicated By Variant Data">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
         <dependency path="internal/jQuery"/>

--- a/mGAP/resources/views/phenotypes.view.xml
+++ b/mGAP/resources/views/phenotypes.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Macaque Phenotypes and Disease Models">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
         <dependency path="internal/jQuery"/>

--- a/mGAP/resources/views/quickLinks.view.xml
+++ b/mGAP/resources/views/quickLinks.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Quick Links">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mGAP/resources/views/releaseNotes.view.xml
+++ b/mGAP/resources/views/releaseNotes.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="mGAP Release Notes">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mGAP/resources/views/tutorials.view.xml
+++ b/mGAP/resources/views/tutorials.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="mGAP Tutorials">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
         <dependency path="internal/jQuery"/>

--- a/mGAP/resources/views/variantList.view.xml
+++ b/mGAP/resources/views/variantList.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Predicted Damaging Variants">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
         <dependency path="laboratory.context"/>

--- a/mGAP/resources/views/variants.view.xml
+++ b/mGAP/resources/views/variants.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mcc/resources/views/U24dashboardWebpart.view.xml
+++ b/mcc/resources/views/U24dashboardWebpart.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="MCC U24 Dashboard">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="gen/U24dashboardWebpart"/>
     </dependencies>

--- a/mcc/resources/views/dashboardWebpart.view.xml
+++ b/mcc/resources/views/dashboardWebpart.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="MCC Dashboard">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="gen/dashboardWebpart"/>
     </dependencies>

--- a/mcc/resources/views/geneticsPlotWebpart.view.xml
+++ b/mcc/resources/views/geneticsPlotWebpart.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Marmoset Genetics">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="gen/geneticsPlotWebpart"/>
     </dependencies>

--- a/mcc/resources/views/helpMenu.view.xml
+++ b/mcc/resources/views/helpMenu.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Help">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
 
     </dependencies>

--- a/mcc/resources/views/manualMccId.view.xml
+++ b/mcc/resources/views/manualMccId.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Manually Assign MCC ID">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.mcc.security.MccDataAdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="mcc.context" />
     </dependencies>

--- a/mcc/resources/views/mccAdmin.view.xml
+++ b/mcc/resources/views/mccAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="MCC Site Admin">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.mcc.security.MccDataAdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="mcc.context" />
     </dependencies>

--- a/mcc/resources/views/mccColonies.view.xml
+++ b/mcc/resources/views/mccColonies.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="MCC Colonies">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mcc/resources/views/mccColony.view.xml
+++ b/mcc/resources/views/mccColony.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="MCC Colony">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/mcc/resources/views/mccFolderInit.view.xml
+++ b/mcc/resources/views/mccFolderInit.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Initialize MCC Study Folder">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="mcc.context" />
     </dependencies>

--- a/mcc/resources/views/mccRequestAdmin.view.xml
+++ b/mcc/resources/views/mccRequestAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="MCC Animal Request Admin">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.mcc.security.MccRequestAdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context" />
         <dependency path="mcc.context" />

--- a/mcc/resources/views/mccRequestSummary.view.xml
+++ b/mcc/resources/views/mccRequestSummary.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="MCC Request Summary">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.mcc.security.MccViewRequestsPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context" />
         <dependency path="mcc.context" />

--- a/mcc/resources/views/mccRequests.view.xml
+++ b/mcc/resources/views/mccRequests.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="MCC Animal Requests">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.mcc.security.MccRequestorPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context" />
         <dependency path="mcc.context" />

--- a/mcc/resources/views/nihReview.view.xml
+++ b/mcc/resources/views/nihReview.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="MCC NIH Review Dashboard">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.mcc.security.MccFinalReviewPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context" />
         <dependency path="mcc.context" />

--- a/mcc/resources/views/rabRequestReview.view.xml
+++ b/mcc/resources/views/rabRequestReview.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="MCC RAB Reviewer Dashboard">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.mcc.security.MccRabReviewPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context" />
         <dependency path="mcc.context" />


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.