### PR TITLE
Complete migration from srcURL and returnURL to returnUrl

### DIFF
--- a/mcc/src/org/labkey/mcc/query/RequestReviewActionsDisplayColumnFactory.java
+++ b/mcc/src/org/labkey/mcc/query/RequestReviewActionsDisplayColumnFactory.java
@@ -4,7 +4,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
@@ -45,7 +44,7 @@ public class RequestReviewActionsDisplayColumnFactory implements DisplayColumnFa
                 String requestId = ctx.get(getBoundKey("requestId"), String.class);
                 Container requestContainer = MccManager.get().getMCCRequestContainer(ctx.getContainer());
                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=rabReview", requestContainer);
-                out.write("<a class=\"labkey-text-link\" href=\"" + url.getActionURL().addReturnURL(ctx.getViewContext().getActionURL()) + "\">Enter Review</a>");
+                out.write("<a class=\"labkey-text-link\" href=\"" + url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL()) + "\">Enter Review</a>");
             }
 
             @Override

--- a/mcc/src/org/labkey/mcc/query/RequestScoreActionsDisplayColumnFactory.java
+++ b/mcc/src/org/labkey/mcc/query/RequestScoreActionsDisplayColumnFactory.java
@@ -76,7 +76,7 @@ public class RequestScoreActionsDisplayColumnFactory implements DisplayColumnFac
                             if (requestContainer.hasPermission(ctx.getViewContext().getUser(), MccRequestAdminPermission.class))
                             {
                                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=primaryReview", requestContainer);
-                                out.write("<br><a class=\"labkey-text-link\" href=\"" + url.getActionURL().addReturnURL(ctx.getViewContext().getActionURL()) + "\">Enter MCC Internal Review</a>");
+                                out.write("<br><a class=\"labkey-text-link\" href=\"" + url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL()) + "\">Enter MCC Internal Review</a>");
                             }
                         }
                         else if (st == MccManager.RequestStatus.RabReview && ctx.get(FieldKey.fromString("pendingRabReviews"), Integer.class) == 0)
@@ -84,7 +84,7 @@ public class RequestScoreActionsDisplayColumnFactory implements DisplayColumnFac
                             if (requestContainer.hasPermission(ctx.getViewContext().getUser(), MccFinalReviewPermission.class))
                             {
                                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=resourceAvailability", requestContainer);
-                                out.write("<br><a class=\"labkey-text-link\" href=\"" + url.getActionURL().addReturnURL(ctx.getViewContext().getActionURL()) + "\">Enter Resource Availability Assessment</a>");
+                                out.write("<br><a class=\"labkey-text-link\" href=\"" + url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL()) + "\">Enter Resource Availability Assessment</a>");
                             }
                         }
                         else if (st == MccManager.RequestStatus.PendingDecision)
@@ -92,7 +92,7 @@ public class RequestScoreActionsDisplayColumnFactory implements DisplayColumnFac
                             if (requestContainer.hasPermission(ctx.getViewContext().getUser(), MccFinalReviewPermission.class))
                             {
                                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=finalReview", requestContainer);
-                                out.write("<br><a class=\"labkey-text-link\" href=\"" + url.getActionURL().addReturnURL(ctx.getViewContext().getActionURL()) + "\">Enter Final Review</a>");
+                                out.write("<br><a class=\"labkey-text-link\" href=\"" + url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL()) + "\">Enter Final Review</a>");
                             }
                         }
                         else if (st == MccManager.RequestStatus.Approved)


### PR DESCRIPTION
#### Rationale
In 2021 we made a major push to use `returnUrl` consistently instead of `srcURL` or `returnURL`. We can finish the job.

Issue 7580: inconsistent use of returnUrl parameter

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6407

#### Changes
- Change everything to `returnUrl` and get rid of code checking for old versions of the parameters