### PR TITLE
Remove unnecessary HttpView.currentView() casts in JSPs

### DIFF
--- a/hivrc/src/org/labkey/hivrc/view/analysisHeader.jsp
+++ b/hivrc/src/org/labkey/hivrc/view/analysisHeader.jsp
@@ -18,7 +18,7 @@
     }
 %>
 <%
-    JspView<AnalysisModel> me = (JspView<AnalysisModel>) HttpView.currentView();
+    JspView<AnalysisModel> me = HttpView.currentView();
     AnalysisModel model = me.getModelBean();
     Integer workbookId = model.getWorkbookId();
     String wpId = "wp_" + me.getWebPartRowId();


### PR DESCRIPTION
#### Rationale
Simple search and replace to clear warnings about unnecessary cast