### PR TITLE
Simplify and expand use of LinkBuilder factory methods

### DIFF
--- a/mGAP/src/org/labkey/mgap/query/OMIMDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/OMIMDisplayColumnFactory.java
@@ -8,6 +8,7 @@ import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 
@@ -59,7 +60,7 @@ public class OMIMDisplayColumnFactory implements DisplayColumnFactory
                     }
 
                     out.write(delim);
-                    out.write(PageFlowUtil.link(text).href("https://www.omim.org/entry/" + id).target("_blank").clearClasses());
+                    out.write(LinkBuilder.simpleLink(text, "https://www.omim.org/entry/" + id).target("_blank"));
                     delim = HtmlString.BR;
                 }
             }

--- a/mGAP/src/org/labkey/mgap/query/OMIMPhenotypeDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/OMIMPhenotypeDisplayColumnFactory.java
@@ -8,6 +8,7 @@ import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 
@@ -68,11 +69,11 @@ public class OMIMPhenotypeDisplayColumnFactory implements DisplayColumnFactory
                     out.write(delim);
                     if (elements.length > 1)
                     {
-                        out.write(PageFlowUtil.link(elements[0]).target("_blank").href("https://www.omim.org/entry/" + elements[1]).clearClasses());
+                        out.write(LinkBuilder.simpleLink(elements[0], "https://www.omim.org/entry/" + elements[1]).target("_blank"));
                     }
                     else
                     {
-                        out.write(PageFlowUtil.link(elements[0]).clearClasses());
+                        out.write(LinkBuilder.simpleLink(elements[0]));
                     }
 
                     delim = HtmlString.BR;

--- a/mGAP/src/org/labkey/mgap/query/OverlappingGenesDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/OverlappingGenesDisplayColumnFactory.java
@@ -8,6 +8,7 @@ import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 
@@ -66,7 +67,7 @@ public class OverlappingGenesDisplayColumnFactory implements DisplayColumnFactor
                     }
 
                     out.write(delim);
-                    out.write(PageFlowUtil.link(geneName).href(url).target("_blank").clearClasses());
+                    out.write(LinkBuilder.simpleLink(geneName, url).target("_blank"));
                     delim = HtmlString.BR;
                 }
             }

--- a/mGAP/src/org/labkey/mgap/query/PhenotypeVariantLinkDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/PhenotypeVariantLinkDisplayColumnFactory.java
@@ -8,6 +8,7 @@ import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 
@@ -52,7 +53,7 @@ public class PhenotypeVariantLinkDisplayColumnFactory implements DisplayColumnFa
                 if (releaseId != null && omim != null)
                 {
                     DetailsURL url = DetailsURL.fromString("/mgap/variantList.view?release=" + releaseId + "&query.omim_phenotype~contains=" + omim, ContainerManager.getForId(containerId));
-                    out.write(PageFlowUtil.link("View Variants").href(url.getActionURL()).addClass("labkey-text-link"));
+                    out.write(LinkBuilder.labkeyLink("View Variants", url.getActionURL()).addClass("labkey-text-link"));
                 }
             }
         };

--- a/mGAP/src/org/labkey/mgap/query/PhenotypeVariantLinkDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/PhenotypeVariantLinkDisplayColumnFactory.java
@@ -9,7 +9,6 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.LinkBuilder;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 
 import java.util.List;
@@ -53,7 +52,7 @@ public class PhenotypeVariantLinkDisplayColumnFactory implements DisplayColumnFa
                 if (releaseId != null && omim != null)
                 {
                     DetailsURL url = DetailsURL.fromString("/mgap/variantList.view?release=" + releaseId + "&query.omim_phenotype~contains=" + omim, ContainerManager.getForId(containerId));
-                    out.write(LinkBuilder.labkeyLink("View Variants", url.getActionURL()).addClass("labkey-text-link"));
+                    out.write(LinkBuilder.labkeyLink("View Variants", url.getActionURL()));
                 }
             }
         };

--- a/mGAP/src/org/labkey/mgap/query/SourceDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/SourceDisplayColumnFactory.java
@@ -9,6 +9,7 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 
@@ -66,7 +67,7 @@ public class SourceDisplayColumnFactory implements DisplayColumnFactory
                 }
                 else
                 {
-                    out.write(PageFlowUtil.link(val).href(url).clearClasses());
+                    out.write(LinkBuilder.simpleLink(val, url));
                 }
             }
 

--- a/mGAP/src/org/labkey/mgap/query/TracksPerReleaseGenomeBrowserDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/TracksPerReleaseGenomeBrowserDisplayColumnFactory.java
@@ -29,7 +29,7 @@ public class TracksPerReleaseGenomeBrowserDisplayColumnFactory extends VariantRe
                 if (jbrowseId != null && trackName != null)
                 {
                     DetailsURL url = DetailsURL.fromString("/mgap/genomeBrowser.view?database=" + jbrowseId + "&activeTracks=" + trackName, ContainerManager.getForId(containerId));
-                    out.write(LinkBuilder.labkeyLink("View In Genome Browser", url.getActionURL()).addClass("labkey-text-link"));
+                    out.write(LinkBuilder.labkeyLink("View In Genome Browser", url.getActionURL()));
                 }
             }
         };

--- a/mGAP/src/org/labkey/mgap/query/TracksPerReleaseGenomeBrowserDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/TracksPerReleaseGenomeBrowserDisplayColumnFactory.java
@@ -5,6 +5,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.DetailsURL;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 
@@ -28,7 +29,7 @@ public class TracksPerReleaseGenomeBrowserDisplayColumnFactory extends VariantRe
                 if (jbrowseId != null && trackName != null)
                 {
                     DetailsURL url = DetailsURL.fromString("/mgap/genomeBrowser.view?database=" + jbrowseId + "&activeTracks=" + trackName, ContainerManager.getForId(containerId));
-                    out.write(PageFlowUtil.link("View In Genome Browser").addClass("labkey-text-link").href(url.getActionURL()));
+                    out.write(LinkBuilder.labkeyLink("View In Genome Browser", url.getActionURL()).addClass("labkey-text-link"));
                 }
             }
         };

--- a/mGAP/src/org/labkey/mgap/query/VariantListJBrowseDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/VariantListJBrowseDisplayColumnFactory.java
@@ -12,6 +12,7 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 
@@ -68,7 +69,7 @@ public class VariantListJBrowseDisplayColumnFactory implements DisplayColumnFact
                 if (jbrowseId != null)
                 {
                     DetailsURL url = DetailsURL.fromString("/jbrowse/browser.view?database=" + jbrowseId + "&location=" + contig + ":" + start + ".." + stop + "&highlight=" + contig + ":" + position + ".." + (position + length - 1), ContainerManager.getForId(containerId));
-                    out.write(PageFlowUtil.link("View In Genome Browser").href(url.getActionURL()).addClass("labkey-text-link"));
+                    out.write(LinkBuilder.labkeyLink("View In Genome Browser", url.getActionURL()).addClass("labkey-text-link"));
                     delim = HtmlString.BR;
                 }
 
@@ -76,7 +77,7 @@ public class VariantListJBrowseDisplayColumnFactory implements DisplayColumnFact
                 {
                     out.write(delim);
                     DetailsURL url = DetailsURL.fromString("/jbrowse/genotypeTable.view?trackId=" + primaryTrack + "&chr=" + contig + "&start=" + position + "&stop=" + position, ContainerManager.getForId(containerId));
-                    out.write(PageFlowUtil.link("View Genotypes At Position").href(url.getActionURL()).addClass("labkey-text-link"));
+                    out.write(LinkBuilder.labkeyLink("View Genotypes At Position", url.getActionURL()).addClass("labkey-text-link"));
                     delim = HtmlString.BR;
                 }
 
@@ -98,7 +99,7 @@ public class VariantListJBrowseDisplayColumnFactory implements DisplayColumnFact
                                 {
                                     String url = "https://www.ncbi.nlm.nih.gov/clinvar/variation/" + parts[1] + "/";
                                     out.write(delim);
-                                    out.write(PageFlowUtil.link("View in ClinVar").href(url));
+                                    out.write(LinkBuilder.labkeyLink("View in ClinVar", url));
                                     delim = HtmlString.BR;
                                 }
                             }
@@ -111,7 +112,7 @@ public class VariantListJBrowseDisplayColumnFactory implements DisplayColumnFact
                 contigE = contigE.replaceAll("^0", "");
                 String url = "https://ensembl.org/Macaca_mulatta/Location/View?db=core;r=" + contigE + ":" + start +"-" + stop;
                 out.write(delim);
-                out.write(PageFlowUtil.link("View Region in Ensembl").href(url));
+                out.write(LinkBuilder.labkeyLink("View Region in Ensembl", url));
             }
         };
     }

--- a/mGAP/src/org/labkey/mgap/query/VariantListJBrowseDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/VariantListJBrowseDisplayColumnFactory.java
@@ -13,7 +13,6 @@ import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.LinkBuilder;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 
 import java.util.List;
@@ -69,7 +68,7 @@ public class VariantListJBrowseDisplayColumnFactory implements DisplayColumnFact
                 if (jbrowseId != null)
                 {
                     DetailsURL url = DetailsURL.fromString("/jbrowse/browser.view?database=" + jbrowseId + "&location=" + contig + ":" + start + ".." + stop + "&highlight=" + contig + ":" + position + ".." + (position + length - 1), ContainerManager.getForId(containerId));
-                    out.write(LinkBuilder.labkeyLink("View In Genome Browser", url.getActionURL()).addClass("labkey-text-link"));
+                    out.write(LinkBuilder.labkeyLink("View In Genome Browser", url.getActionURL()));
                     delim = HtmlString.BR;
                 }
 
@@ -77,7 +76,7 @@ public class VariantListJBrowseDisplayColumnFactory implements DisplayColumnFact
                 {
                     out.write(delim);
                     DetailsURL url = DetailsURL.fromString("/jbrowse/genotypeTable.view?trackId=" + primaryTrack + "&chr=" + contig + "&start=" + position + "&stop=" + position, ContainerManager.getForId(containerId));
-                    out.write(LinkBuilder.labkeyLink("View Genotypes At Position", url.getActionURL()).addClass("labkey-text-link"));
+                    out.write(LinkBuilder.labkeyLink("View Genotypes At Position", url.getActionURL()));
                     delim = HtmlString.BR;
                 }
 

--- a/mGAP/src/org/labkey/mgap/query/VariantReleaseDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/VariantReleaseDisplayColumnFactory.java
@@ -10,6 +10,7 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.template.ClientDependency;
@@ -53,7 +54,7 @@ public class VariantReleaseDisplayColumnFactory implements DisplayColumnFactory
                 Integer rowId = ctx.get(getBoundKey("rowid"), Integer.class);
                 if (rowId != null)
                 {
-                    out.write(PageFlowUtil.link("Download").
+                    out.write(LinkBuilder.labkeyLink("Download").
                             addClass("vrdc-row").
                             attributes(PageFlowUtil.map("data-rowid", rowId.toString()))
                     );
@@ -76,7 +77,7 @@ public class VariantReleaseDisplayColumnFactory implements DisplayColumnFactory
                     }
 
                     DetailsURL url = DetailsURL.fromString("/jbrowse/browser.view?database=" + jbrowseId, ContainerManager.getForId(containerId));
-                    out.write(PageFlowUtil.link("View In Genome Browser", url.getActionURL()));
+                    out.write(LinkBuilder.labkeyLink("View In Genome Browser", url.getActionURL()));
                 }
 
                 Boolean showVariantList = ctx.get(getBoundKey("hasSignificantVariants"), Boolean.class);
@@ -85,7 +86,7 @@ public class VariantReleaseDisplayColumnFactory implements DisplayColumnFactory
                     out.write(HtmlString.BR);
 
                     DetailsURL url = DetailsURL.fromString("/mgap/variantList.view?release=" + rowId, ContainerManager.getForId(containerId));
-                    out.write(PageFlowUtil.link("Significant Variant List", url.getActionURL()));
+                    out.write(LinkBuilder.labkeyLink("Significant Variant List", url.getActionURL()));
                 }
             }
 

--- a/mGAP/src/org/labkey/mgap/query/VariantReleaseGenomeBrowserDisplayColumnFactory.java
+++ b/mGAP/src/org/labkey/mgap/query/VariantReleaseGenomeBrowserDisplayColumnFactory.java
@@ -8,6 +8,7 @@ import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 
@@ -73,7 +74,7 @@ public class VariantReleaseGenomeBrowserDisplayColumnFactory implements DisplayC
             if (jbrowseId != null)
             {
                 DetailsURL url = DetailsURL.fromString("/jbrowse/browser.view?database=" + jbrowseId, ContainerManager.getForId(containerId));
-                out.write(PageFlowUtil.link("View In Genome Browser", url.getActionURL()));
+                out.write(LinkBuilder.labkeyLink("View In Genome Browser", url.getActionURL()));
             }
         }
 

--- a/mcc/src/org/labkey/mcc/query/AnimalRequestActionsDisplayColumnFactory.java
+++ b/mcc/src/org/labkey/mcc/query/AnimalRequestActionsDisplayColumnFactory.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 import org.labkey.api.data.RenderContext;
@@ -26,7 +27,7 @@ public class AnimalRequestActionsDisplayColumnFactory implements DisplayColumnFa
             public void renderGridCellContents(RenderContext ctx, HtmlWriter out)
             {
                 int rowId = ctx.get(getBoundKey("rowid"), Integer.class);
-                out.write(PageFlowUtil.link("Contact MCC").href("mailto:" + MccManager.get().getMccAdminEmail() + "?subject=MCC Request #" + rowId));
+                out.write(LinkBuilder.labkeyLink("Contact MCC", "mailto:" + MccManager.get().getMccAdminEmail() + "?subject=MCC Request #" + rowId));
             }
 
             @Override

--- a/mcc/src/org/labkey/mcc/query/RequestReviewActionsDisplayColumnFactory.java
+++ b/mcc/src/org/labkey/mcc/query/RequestReviewActionsDisplayColumnFactory.java
@@ -12,7 +12,6 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.util.LinkBuilder;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 import org.labkey.mcc.MccManager;
 
@@ -45,7 +44,7 @@ public class RequestReviewActionsDisplayColumnFactory implements DisplayColumnFa
                 String requestId = ctx.get(getBoundKey("requestId"), String.class);
                 Container requestContainer = MccManager.get().getMCCRequestContainer(ctx.getContainer());
                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=rabReview", requestContainer);
-                out.write(LinkBuilder.labkeyLink("Enter Review", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())).addClass("labkey-text-link"));
+                out.write(LinkBuilder.labkeyLink("Enter Review", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())));
             }
 
             @Override

--- a/mcc/src/org/labkey/mcc/query/RequestReviewActionsDisplayColumnFactory.java
+++ b/mcc/src/org/labkey/mcc/query/RequestReviewActionsDisplayColumnFactory.java
@@ -11,6 +11,7 @@ import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.HtmlWriter;
 import org.labkey.mcc.MccManager;
@@ -44,7 +45,7 @@ public class RequestReviewActionsDisplayColumnFactory implements DisplayColumnFa
                 String requestId = ctx.get(getBoundKey("requestId"), String.class);
                 Container requestContainer = MccManager.get().getMCCRequestContainer(ctx.getContainer());
                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=rabReview", requestContainer);
-                out.write(PageFlowUtil.link("Enter Review").href(url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())).addClass("labkey-text-link"));
+                out.write(LinkBuilder.labkeyLink("Enter Review", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())).addClass("labkey-text-link"));
             }
 
             @Override

--- a/mcc/src/org/labkey/mcc/query/RequestScoreActionsDisplayColumnFactory.java
+++ b/mcc/src/org/labkey/mcc/query/RequestScoreActionsDisplayColumnFactory.java
@@ -50,7 +50,7 @@ public class RequestScoreActionsDisplayColumnFactory implements DisplayColumnFac
                         return;
                     }
 
-                    out.write(LinkBuilder.labkeyLink("Contact Investigator", "mailto:" + u.getEmail() + "?subject=MCC Request #" + requestRowId).addClass("labkey-text-link"));
+                    out.write(LinkBuilder.labkeyLink("Contact Investigator", "mailto:" + u.getEmail() + "?subject=MCC Request #" + requestRowId));
                 }
 
                 String status = ctx.get(getBoundKey("requestId", "status"), String.class);
@@ -78,7 +78,7 @@ public class RequestScoreActionsDisplayColumnFactory implements DisplayColumnFac
                             {
                                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=primaryReview", requestContainer);
                                 out.write(HtmlString.BR);
-                                out.write(LinkBuilder.labkeyLink("Enter MCC Internal Review", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())).addClass("labkey-text-link"));
+                                out.write(LinkBuilder.labkeyLink("Enter MCC Internal Review", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())));
                             }
                         }
                         else if (st == MccManager.RequestStatus.RabReview && ctx.get(FieldKey.fromString("pendingRabReviews"), Integer.class) == 0)
@@ -87,7 +87,7 @@ public class RequestScoreActionsDisplayColumnFactory implements DisplayColumnFac
                             {
                                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=resourceAvailability", requestContainer);
                                 out.write(HtmlString.BR);
-                                out.write(LinkBuilder.labkeyLink("Enter Resource Availability Assessment", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())).addClass("labkey-text-link"));
+                                out.write(LinkBuilder.labkeyLink("Enter Resource Availability Assessment", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())));
                             }
                         }
                         else if (st == MccManager.RequestStatus.PendingDecision)
@@ -96,7 +96,7 @@ public class RequestScoreActionsDisplayColumnFactory implements DisplayColumnFac
                             {
                                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=finalReview", requestContainer);
                                 out.write(HtmlString.BR);
-                                out.write(LinkBuilder.labkeyLink("Enter Final Review", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())).addClass("labkey-text-link"));
+                                out.write(LinkBuilder.labkeyLink("Enter Final Review", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())));
                             }
                         }
                         else if (st == MccManager.RequestStatus.Approved)

--- a/mcc/src/org/labkey/mcc/query/RequestScoreActionsDisplayColumnFactory.java
+++ b/mcc/src/org/labkey/mcc/query/RequestScoreActionsDisplayColumnFactory.java
@@ -13,6 +13,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.template.ClientDependency;
@@ -49,7 +50,7 @@ public class RequestScoreActionsDisplayColumnFactory implements DisplayColumnFac
                         return;
                     }
 
-                    out.write(PageFlowUtil.link("Contact Investigator").addClass("labkey-text-link").href("mailto:" + u.getEmail() + "?subject=MCC Request #" + requestRowId));
+                    out.write(LinkBuilder.labkeyLink("Contact Investigator", "mailto:" + u.getEmail() + "?subject=MCC Request #" + requestRowId).addClass("labkey-text-link"));
                 }
 
                 String status = ctx.get(getBoundKey("requestId", "status"), String.class);
@@ -77,7 +78,7 @@ public class RequestScoreActionsDisplayColumnFactory implements DisplayColumnFac
                             {
                                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=primaryReview", requestContainer);
                                 out.write(HtmlString.BR);
-                                out.write(PageFlowUtil.link("Enter MCC Internal Review").addClass("labkey-text-link").href(url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())));
+                                out.write(LinkBuilder.labkeyLink("Enter MCC Internal Review", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())).addClass("labkey-text-link"));
                             }
                         }
                         else if (st == MccManager.RequestStatus.RabReview && ctx.get(FieldKey.fromString("pendingRabReviews"), Integer.class) == 0)
@@ -86,7 +87,7 @@ public class RequestScoreActionsDisplayColumnFactory implements DisplayColumnFac
                             {
                                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=resourceAvailability", requestContainer);
                                 out.write(HtmlString.BR);
-                                out.write(PageFlowUtil.link("Enter Resource Availability Assessment").addClass("labkey-text-link").href(url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())));
+                                out.write(LinkBuilder.labkeyLink("Enter Resource Availability Assessment", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())).addClass("labkey-text-link"));
                             }
                         }
                         else if (st == MccManager.RequestStatus.PendingDecision)
@@ -95,16 +96,17 @@ public class RequestScoreActionsDisplayColumnFactory implements DisplayColumnFac
                             {
                                 DetailsURL url = DetailsURL.fromString("/mcc/requestReview.view?requestId=" + requestId + "&mode=finalReview", requestContainer);
                                 out.write(HtmlString.BR);
-                                out.write(PageFlowUtil.link("Enter Final Review").addClass("labkey-text-link").href(url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())));
+                                out.write(LinkBuilder.labkeyLink("Enter Final Review", url.getActionURL().addReturnUrl(ctx.getViewContext().getActionURL())).addClass("labkey-text-link"));
                             }
                         }
                         else if (st == MccManager.RequestStatus.Approved)
                         {
                             out.write(HtmlString.BR);
-                            out.write(PageFlowUtil.link("Mark Fulfilled").
+                            out.write(LinkBuilder.labkeyLink("Mark Fulfilled").
                                     addClass("labkey-text-link").
                                     addClass("rsadc-approved").
-                                    attributes(PageFlowUtil.map("data-requestrowid", String.valueOf(requestRowId))));
+                                    attributes(PageFlowUtil.map("data-requestrowid", String.valueOf(requestRowId)))
+                            );
 
                             if (!_hasRegisteredApprovedHandler)
                             {


### PR DESCRIPTION
#### Rationale
Using `LinkBuilder` factory methods simplifies the creation of links and provides consistency & clarity

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6561