### PR TITLE
Support BIGINT Primary Keys

### DIFF
--- a/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysController.java
+++ b/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysController.java
@@ -130,7 +130,7 @@ public class GenotypeAssaysController extends SpringActionController
                         return null;
                     }
 
-                    Pair<List<Integer>, List<Integer>> ret = GenotypeAssaysManager.get().cacheAnalyses(getViewContext(), protocol, form.getAlleleNames());
+                    Pair<List<Long>, List<Long>> ret = GenotypeAssaysManager.get().cacheAnalyses(getViewContext(), protocol, form.getAlleleNames());
                     resultProperties.put("runsCreated", ret.first);
                     resultProperties.put("runsDeleted", ret.second);
                 }
@@ -209,7 +209,7 @@ public class GenotypeAssaysController extends SpringActionController
                         return null;
                     }
 
-                    Pair<List<Integer>, List<Integer>> ret = GenotypeAssaysManager.get().cacheHaplotypes(getViewContext(), protocol, new JSONArray(form.getJson()));
+                    Pair<List<Long>, List<Long>> ret = GenotypeAssaysManager.get().cacheHaplotypes(getViewContext(), protocol, new JSONArray(form.getJson()));
                     resultProperties.put("runsCreated", ret.first);
                     resultProperties.put("runsDeleted", ret.second);
                 }

--- a/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysManager.java
+++ b/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysManager.java
@@ -88,11 +88,11 @@ public class GenotypeAssaysManager
     }
 
 
-    public Pair<List<Integer>, List<Integer>> cacheAnalyses(final ViewContext ctx, final ExpProtocol protocol, String[] pks) throws IllegalArgumentException
+    public Pair<List<Long>, List<Long>> cacheAnalyses(final ViewContext ctx, final ExpProtocol protocol, String[] pks) throws IllegalArgumentException
     {
         final User u = ctx.getUser();
-        final List<Integer> runsCreated = new ArrayList<>();
-        final List<Integer> runsDeleted = new ArrayList<>();
+        final List<Long> runsCreated = new ArrayList<>();
+        final List<Long> runsDeleted = new ArrayList<>();
 
         try (DbScope.Transaction transaction = DbScope.getLabKeyScope().ensureTransaction())
         {
@@ -178,11 +178,11 @@ public class GenotypeAssaysManager
         }
     }
 
-    public Pair<List<Integer>, List<Integer>> cacheHaplotypes(final ViewContext ctx, final ExpProtocol protocol, JSONArray data) throws IllegalArgumentException
+    public Pair<List<Long>, List<Long>> cacheHaplotypes(final ViewContext ctx, final ExpProtocol protocol, JSONArray data) throws IllegalArgumentException
     {
         final User u = ctx.getUser();
-        final List<Integer> runsCreated = new ArrayList<>();
-        final List<Integer> runsDeleted = new ArrayList<>();
+        final List<Long> runsCreated = new ArrayList<>();
+        final List<Long> runsDeleted = new ArrayList<>();
 
         //next identify a build up the results
         TableInfo tableAnalyses = QueryService.get().getUserSchema(u, ctx.getContainer(), SEQUENCEANALYSIS_SCHEMA).getTable("sequence_analyses");
@@ -288,7 +288,7 @@ public class GenotypeAssaysManager
         return Pair.of(runsCreated, runsDeleted);
     }
 
-    private void processSet(String assayType, Map<Integer, List<Map<String, Object>>> rowHash, TableInfo assayDataTable, User u, ViewContext ctx, Map<Integer, Set<Integer>> toDeleteByAnalysis, AssayProvider ap, ExpProtocol protocol, List<Integer> runsCreated)
+    private void processSet(String assayType, Map<Integer, List<Map<String, Object>>> rowHash, TableInfo assayDataTable, User u, ViewContext ctx, Map<Integer, Set<Integer>> toDeleteByAnalysis, AssayProvider ap, ExpProtocol protocol, List<Long> runsCreated)
     {
         for (Integer analysisId : rowHash.keySet())
         {

--- a/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysManager.java
+++ b/GenotypeAssays/src/org/labkey/genotypeassays/GenotypeAssaysManager.java
@@ -24,6 +24,8 @@ import org.labkey.api.assay.AssayProtocolSchema;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.IntHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -118,8 +120,8 @@ public class GenotypeAssaysManager
             AssayProtocolSchema schema = ap.createProtocolSchema(u, ctx.getContainer(), protocol, null);
             final TableInfo assayDataTable = schema.getTable(AssayProtocolSchema.DATA_TABLE_NAME);
 
-            final Map<Integer, List<Map<String, Object>>> rowHash = new HashMap<>();
-            final Map<Integer, Set<Integer>> toDeleteByAnalysis = new HashMap<>();
+            final Map<Integer, List<Map<String, Object>>> rowHash = new IntHashMap<>();
+            final Map<Integer, Set<Integer>> toDeleteByAnalysis = new IntHashMap<>();
 
             TableSelector tsAlignments = new TableSelector(tableAlignments, cols.values(), new SimpleFilter(FieldKey.fromString("key"), Arrays.asList(pks), CompareType.IN), null);
             tsAlignments.forEach(new Selector.ForEachBlock<ResultSet>()
@@ -139,7 +141,7 @@ public class GenotypeAssaysManager
                     filter.addCondition(FieldKey.fromString("Run/assayType"), SBT_LINEAGE_ASSAY_TYPE);
 
                     TableSelector ts = new TableSelector(assayDataTable, PageFlowUtil.set("RowId"), filter, null);
-                    Set<Integer> existing = new HashSet<>(ts.getArrayList(Integer.class));
+                    Set<Integer> existing = new IntHashSet(ts.getArrayList(Integer.class));
                     if (!existing.isEmpty())
                     {
                         Set<Integer> toDelete = toDeleteByAnalysis.containsKey(analysisId) ? toDeleteByAnalysis.get(analysisId) : new HashSet<Integer>();
@@ -196,8 +198,8 @@ public class GenotypeAssaysManager
         fieldKeys.add(FieldKey.fromString("readset/subjectid"));
         fieldKeys.add(FieldKey.fromString("readset/sampledate"));
 
-        Set<Integer> analysisIds = new HashSet<>();
-        final Map<Integer, List<JSONObject>> haploMap = new HashMap<>();
+        Set<Integer> analysisIds = new IntHashSet();
+        final Map<Integer, List<JSONObject>> haploMap = new IntHashMap<>();
         for (JSONObject row : JsonUtil.toJSONObjectList(data))
         {
             Integer analysisId = row.getInt("analysisId");
@@ -217,8 +219,8 @@ public class GenotypeAssaysManager
         AssayProtocolSchema schema = ap.createProtocolSchema(u, ctx.getContainer(), protocol, null);
         final TableInfo assayDataTable = schema.getTable(AssayProtocolSchema.DATA_TABLE_NAME);
 
-        final Map<Integer, List<Map<String, Object>>> rowHash = new HashMap<>();
-        final Map<Integer, Set<Integer>> toDeleteByAnalysis = new HashMap<>();
+        final Map<Integer, List<Map<String, Object>>> rowHash = new IntHashMap<>();
+        final Map<Integer, Set<Integer>> toDeleteByAnalysis = new IntHashMap<>();
 
         TableSelector tsAlignments = new TableSelector(tableAnalyses, cols.values(), new SimpleFilter(FieldKey.fromString("rowid"), analysisIds, CompareType.IN), null);
         tsAlignments.forEach(new Selector.ForEachBlock<ResultSet>()
@@ -244,10 +246,10 @@ public class GenotypeAssaysManager
                     filter.addCondition(FieldKey.fromString("Run/assayType"), HAPLOTYPE_ASSAY_TYPE);
 
                     TableSelector ts = new TableSelector(assayDataTable, PageFlowUtil.set("RowId"), filter, null);
-                    Set<Integer> existing = new HashSet<>(ts.getArrayList(Integer.class));
+                    Set<Integer> existing = new IntHashSet(ts.getArrayList(Integer.class));
                     if (!existing.isEmpty())
                     {
-                        Set<Integer> toDelete = toDeleteByAnalysis.containsKey(analysisId) ? toDeleteByAnalysis.get(analysisId) : new HashSet<>();
+                        Set<Integer> toDelete = toDeleteByAnalysis.containsKey(analysisId) ? toDeleteByAnalysis.get(analysisId) : new IntHashSet();
                         toDelete.addAll(existing);
                         toDeleteByAnalysis.put(analysisId, toDelete);
                     }

--- a/elispot_assay/src/org/labkey/elispot_assay/assay/DefaultImportMethod.java
+++ b/elispot_assay/src/org/labkey/elispot_assay/assay/DefaultImportMethod.java
@@ -32,6 +32,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 /**
  * Created with IntelliJ IDEA.
  * User: bimber
@@ -134,7 +136,7 @@ public class DefaultImportMethod extends DefaultAssayImportMethod
 
             if (TYPE.NEG.getText().equals(row.get(CATEGORY_FIELD)))
             {
-                Integer spots = (Integer)row.get(SPOTS_FIELD);
+                Integer spots = asInteger(row.get(SPOTS_FIELD));
                 List<Double> negCtls = negWellMap.get(negCtlKey);
                 if (negCtls == null)
                     negCtls = new ArrayList<Double>();
@@ -188,8 +190,8 @@ public class DefaultImportMethod extends DefaultAssayImportMethod
             int rowIdx = 0;
             for (Map<String, Object> row : rowSet)
             {
-                totalSpots += (Integer)row.get(SPOTS_FIELD);
-                allSpots[rowIdx] = (Integer)row.get(SPOTS_FIELD);
+                totalSpots += asInteger(row.get(SPOTS_FIELD));
+                allSpots[rowIdx] = asInteger(row.get(SPOTS_FIELD));
                 rowIdx++;
             }
             Double avgSpots = totalSpots / rowSet.size();
@@ -262,7 +264,7 @@ public class DefaultImportMethod extends DefaultAssayImportMethod
                     row.put(QCFLAG_FIELD, StringUtils.join(qcflags, "\n"));
 
                 //subtract background
-                Integer spots = (Integer)row.get(SPOTS_FIELD);
+                Integer spots = asInteger(row.get(SPOTS_FIELD));
                 Double adj = spots - negCtlSummary.getMean();
                 List<String> comments = new ArrayList<String>();
                 if (row.get("comment") != null)

--- a/mGAP/src/org/labkey/mgap/mGAPController.java
+++ b/mGAP/src/org/labkey/mgap/mGAPController.java
@@ -122,6 +122,8 @@ import java.util.TreeSet;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 
 public class mGAPController extends SpringActionController
 {
@@ -413,7 +415,7 @@ public class mGAPController extends SpringActionController
                     User u;
                     if (map.get("userId") != null)
                     {
-                        Integer userId = (Integer) map.get("userId");
+                        Integer userId = asInteger(map.get("userId"));
                         u = UserManager.getUser(userId);
                         existingUsersGivenAccess.add(u);
                     }
@@ -556,7 +558,7 @@ public class mGAPController extends SpringActionController
 
     private static SequenceOutputFile getOutputFile(Map<String, Object> row, ReleaseForm form, Errors errors)
     {
-        SequenceOutputFile so = SequenceOutputFile.getForId((Integer) row.get("vcfId"));
+        SequenceOutputFile so = SequenceOutputFile.getForId(asInteger(row.get("vcfId")));
         if (so == null)
         {
             errors.reject(ERROR_MSG, "Unknown VCF file ID: " + form.getReleaseId());

--- a/mcc/src/org/labkey/mcc/MccController.java
+++ b/mcc/src/org/labkey/mcc/MccController.java
@@ -104,6 +104,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 public class MccController extends SpringActionController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(MccController.class);
@@ -356,7 +358,7 @@ public class MccController extends SpringActionController
                     User u;
                     if (map.get("userId") != null)
                     {
-                        Integer userId = (Integer)map.get("userId");
+                        Integer userId = asInteger(map.get("userId"));
                         u = UserManager.getUser(userId);
                         existingUsersGivenAccess.add(u);
                     }

--- a/mcc/src/org/labkey/mcc/query/TriggerHelper.java
+++ b/mcc/src/org/labkey/mcc/query/TriggerHelper.java
@@ -49,6 +49,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 /**
  * Created by bimber
  */
@@ -135,7 +137,7 @@ public class TriggerHelper
                 }
 
                 Map<String, Object> row = records.get(0);
-                if (score != (Integer)row.get("preliminaryScore"))
+                if (score != asInteger(row.get("preliminaryScore")))
                 {
                     row.put("preliminaryScore", score);
                     row.put("modified", new Date());

--- a/primeseq/src/org/labkey/primeseq/analysis/MethylationRateComparisonHandler.java
+++ b/primeseq/src/org/labkey/primeseq/analysis/MethylationRateComparisonHandler.java
@@ -15,6 +15,8 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.StringHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.jbrowse.JBrowseService;
 import org.labkey.api.module.Module;
@@ -49,7 +51,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -188,7 +189,7 @@ public class MethylationRateComparisonHandler implements SequenceOutputHandler<S
                 ctx.getLogger().info(groupNames.getString(i));
             }
 
-            Map<Integer, Integer> fileToGroupMap = new HashMap<>();
+            Map<Integer, Integer> fileToGroupMap = new IntHashMap<>();
             JSONObject map = ctx.getParams().getJSONObject("fileToGroupMap");
             for (String id : map.keySet())
             {
@@ -201,7 +202,7 @@ public class MethylationRateComparisonHandler implements SequenceOutputHandler<S
             String statisticalMethod = ctx.getParams().optString("statisticalMethod");
 
             //build map of site rates
-            Map<String, Map<Integer, Map<Integer, List<Double>>>> rateMap = new HashMap<>();
+            Map<String, Map<Integer, Map<Integer, List<Double>>>> rateMap = new StringHashMap<>();
 
             int i = 0;
             for (SequenceOutputFile o : inputFiles)
@@ -268,12 +269,12 @@ public class MethylationRateComparisonHandler implements SequenceOutputHandler<S
 
                         if (!rateMap.containsKey(chr))
                         {
-                            rateMap.put(chr, new HashMap<>());
+                            rateMap.put(chr, new IntHashMap<>());
                         }
 
                         if (!rateMap.get(chr).containsKey(pos))
                         {
-                            rateMap.get(chr).put(pos, new HashMap<>());
+                            rateMap.get(chr).put(pos, new IntHashMap<>());
                         }
 
                         if (!rateMap.get(chr).get(pos).containsKey(groupNum))

--- a/primeseq/src/org/labkey/primeseq/pipeline/BismarkWrapper.java
+++ b/primeseq/src/org/labkey/primeseq/pipeline/BismarkWrapper.java
@@ -511,7 +511,7 @@ public class BismarkWrapper extends AbstractCommandWrapper
         @Override
         public Output performAnalysisPerSampleLocal(AnalysisModel model, File inputBam, File referenceFasta, File outDir) throws PipelineJobException
         {
-            Integer runId = SequenceAnalysisService.get().getExpRunIdForJob(getPipelineCtx().getJob(), true);
+            Long runId = SequenceAnalysisService.get().getExpRunIdForJob(getPipelineCtx().getJob(), true);
 
             Set<SequenceOutputFile> toCreate = new HashSet<>();
             SequenceOutputTracker sot = ((SequenceOutputTracker)getPipelineCtx().getJob());

--- a/primeseq/src/org/labkey/primeseq/pipeline/MhcMigrationPipelineJob.java
+++ b/primeseq/src/org/labkey/primeseq/pipeline/MhcMigrationPipelineJob.java
@@ -5,6 +5,8 @@ import org.json.JSONObject;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.LongHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -397,10 +399,11 @@ public class MhcMigrationPipelineJob extends PipelineJob
                         continue;
                     }
 
-                    final Map<Integer, Integer> alignmentSummaryMap = new HashMap<>(srr.getRowCount().intValue());
+                    final Map<Integer, Integer> alignmentSummaryMap = new IntHashMap<>(srr.getRowCount().intValue());
                     srr.getRowset().forEach(rs -> {
                         CaseInsensitiveHashMap<Object> map = new CaseInsensitiveHashMap<>();
-                        Integer localId = analysisMap.get(rs.getValue("analysis_id"));
+                        Number analysisId = (Number)rs.getValue("analysis_id");
+                        Integer localId = analysisMap.get(analysisId.intValue());
                         if (localId == null)
                         {
                             throw new RuntimeException("Unable to find analysis: " + rs.getValue("analysis_id"));
@@ -640,16 +643,16 @@ public class MhcMigrationPipelineJob extends PipelineJob
 
         //All of these map remote Id to local Id
         private final Map<Integer, Container> workbookMap = new TreeMap<>();
-        private final Map<Integer, Integer> readsetMap = new HashMap<>();
-        private final Map<Integer, Integer> readdataMap = new HashMap<>();
-        private final Map<Integer, Integer> analysisMap = new HashMap<>();
-        private final Map<Integer, Integer> analysisToFileMap = new HashMap<>(); //local analysis_id -> alignment file
-        private final Map<Integer, String> analysisToJobPath = new HashMap<>();
-        private final Map<Integer, Integer> libraryMap = new HashMap<>();
-        private final Map<Integer, Integer> outputFileMap = new HashMap<>();
-        private final Map<Integer, Integer> sequenceMap = new HashMap<>();
-        private final Map<Long, Long> runIdMap = new HashMap<>(5000);
-        private final Map<Integer, Integer> jobIdMap = new HashMap<>(5000);
+        private final Map<Integer, Integer> readsetMap = new IntHashMap<>();
+        private final Map<Integer, Integer> readdataMap = new IntHashMap<>();
+        private final Map<Integer, Integer> analysisMap = new IntHashMap<>();
+        private final Map<Integer, Integer> analysisToFileMap = new IntHashMap<>(); //local analysis_id -> alignment file
+        private final Map<Integer, String> analysisToJobPath = new IntHashMap<>();
+        private final Map<Integer, Integer> libraryMap = new IntHashMap<>();
+        private final Map<Integer, Integer> outputFileMap = new IntHashMap<>();
+        private final Map<Integer, Integer> sequenceMap = new IntHashMap<>();
+        private final Map<Long, Long> runIdMap = new LongHashMap<>(5000);
+        private final Map<Integer, Integer> jobIdMap = new IntHashMap<>(5000);
         private final Map<URI, Long> expDataMap = new HashMap<>(10000);
 
         private void createLibraryMembers(Set<String> preExisting)

--- a/primeseq/src/org/labkey/primeseq/pipeline/MhcMigrationPipelineJob.java
+++ b/primeseq/src/org/labkey/primeseq/pipeline/MhcMigrationPipelineJob.java
@@ -648,9 +648,9 @@ public class MhcMigrationPipelineJob extends PipelineJob
         private final Map<Integer, Integer> libraryMap = new HashMap<>();
         private final Map<Integer, Integer> outputFileMap = new HashMap<>();
         private final Map<Integer, Integer> sequenceMap = new HashMap<>();
-        private final Map<Integer, Integer> runIdMap = new HashMap<>(5000);
+        private final Map<Long, Long> runIdMap = new HashMap<>(5000);
         private final Map<Integer, Integer> jobIdMap = new HashMap<>(5000);
-        private final Map<URI, Integer> expDataMap = new HashMap<>(10000);
+        private final Map<URI, Long> expDataMap = new HashMap<>(10000);
 
         private void createLibraryMembers(Set<String> preExisting)
         {
@@ -970,7 +970,7 @@ public class MhcMigrationPipelineJob extends PipelineJob
                             //Create run:
                             if (rd.getValue("runid") != null && rd.getValue("runid/JobId") != null)
                             {
-                                int runId = createExpRun(Integer.parseInt(String.valueOf(rd.getValue("runid"))), targetWorkbook, String.valueOf(rd.getValue("runid/Name")), jobId);
+                                long runId = createExpRun(Integer.parseInt(String.valueOf(rd.getValue("runid"))), targetWorkbook, String.valueOf(rd.getValue("runid/Name")), jobId);
                                 toCreate.put("runid", runId);
                             }
                             else
@@ -1126,7 +1126,7 @@ public class MhcMigrationPipelineJob extends PipelineJob
                             //Create run:
                             if (rd.getValue("runid") != null && rd.getValue("runid/JobId") != null)
                             {
-                                int runId = createExpRun(Integer.parseInt(String.valueOf(rd.getValue("runid"))), targetWorkbook, String.valueOf(rd.getValue("runid/Name")), jobId);
+                                long runId = createExpRun(Integer.parseInt(String.valueOf(rd.getValue("runid"))), targetWorkbook, String.valueOf(rd.getValue("runid/Name")), jobId);
                                 toCreate.put("runid", runId);
                             }
                             else
@@ -1293,7 +1293,7 @@ public class MhcMigrationPipelineJob extends PipelineJob
                                 //Create run:
                                 if (rd.getValue("runid") != null && jobId != null)
                                 {
-                                    int runId = createExpRun(Integer.parseInt(String.valueOf(rd.getValue("runid"))), targetWorkbook, String.valueOf(rd.getValue("runid/Name")), jobId);
+                                    long runId = createExpRun(Integer.parseInt(String.valueOf(rd.getValue("runid"))), targetWorkbook, String.valueOf(rd.getValue("runid/Name")), jobId);
                                     toCreate.put("runid", runId);
                                 }
                                 else
@@ -1359,7 +1359,7 @@ public class MhcMigrationPipelineJob extends PipelineJob
         private int createdExpData = 0;
         private int expDataCacheHits = 0;
 
-        private int getOrCreateExpData(URI uri, Container workbook, String fileName)
+        private long getOrCreateExpData(URI uri, Container workbook, String fileName)
         {
             if (uri.toString().contains("/C:/"))
             {
@@ -1473,7 +1473,7 @@ public class MhcMigrationPipelineJob extends PipelineJob
                             {
                                 int remoteJobId = Integer.parseInt(String.valueOf(rs.getValue("runid/JobId")));
                                 int jobId = getOrCreateJob(remoteJobId, targetWorkbook);
-                                int runid = createExpRun(Integer.parseInt(String.valueOf(rs.getValue("runid"))), targetWorkbook, String.valueOf(rs.getValue("runid/Name")), jobId);
+                                long runid = createExpRun(Integer.parseInt(String.valueOf(rs.getValue("runid"))), targetWorkbook, String.valueOf(rs.getValue("runid/Name")), jobId);
                                 toCreate.put("runid", runid);
                             }
                             else if (rs.getValue("totalForwardReads") != null)
@@ -1670,7 +1670,7 @@ public class MhcMigrationPipelineJob extends PipelineJob
             }
         }
 
-        private int createExpRun(int remoteId, Container c, String name, int localJobId) throws Exception
+        private long createExpRun(long remoteId, Container c, String name, long localJobId) throws Exception
         {
             if (runIdMap.containsKey(remoteId))
             {
@@ -1681,7 +1681,7 @@ public class MhcMigrationPipelineJob extends PipelineJob
             TableSelector ts = new TableSelector(ExperimentService.get().getTinfoExperimentRun(), PageFlowUtil.set("RowId"), new SimpleFilter(FieldKey.fromString("JobId"), localJobId), null);
             if (ts.exists())
             {
-                List<Integer> rowIds = ts.getArrayList(Integer.class);
+                List<Long> rowIds = ts.getArrayList(Long.class);
                 Collections.sort(rowIds, Comparator.reverseOrder());
                 runIdMap.put(remoteId, rowIds.get(0));
 

--- a/tcrdb/src/org/labkey/tcrdb/TCRdbController.java
+++ b/tcrdb/src/org/labkey/tcrdb/TCRdbController.java
@@ -26,6 +26,9 @@ import org.labkey.api.action.ConfirmAction;
 import org.labkey.api.action.ExportAction;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.IntHashSet;
+import org.labkey.api.collections.StringHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -528,7 +531,7 @@ public class TCRdbController extends SpringActionController
             }
 
             StringBuilder fasta = new StringBuilder();
-            Map<Integer, Set<String>> segmentsByLibrary = new HashMap<>();
+            Map<Integer, Set<String>> segmentsByLibrary = new IntHashMap<>();
 
             //find assay records
             SimpleFilter assayFilter = new SimpleFilter(FieldKey.fromString("rowId"), rowIds, CompareType.IN);
@@ -689,12 +692,12 @@ public class TCRdbController extends SpringActionController
 
             TableSelector ts = new TableSelector(assayData, cols.values(), assayFilter, null);
             Set<String> segmentsByName = new HashSet<>();
-            Map<Integer, Set<String>> segmentsByLibrary = new HashMap<>();
+            Map<Integer, Set<String>> segmentsByLibrary = new IntHashMap<>();
 
-            Map<Integer, Set<String>> clnaToCloneMap = new HashMap<>();
-            Map<String, String> clnaToCDR3Map = new HashMap<>();
+            Map<Integer, Set<String>> clnaToCloneMap = new IntHashMap<>();
+            Map<String, String> clnaToCDR3Map = new StringHashMap<>();
             StringBuilder imputedSequences = new StringBuilder();
-            Set<Integer> analyses = new HashSet<>();
+            Set<Integer> analyses = new IntHashSet();
             final String[] segmentFields = new String[]{"vHit", "jHit", "cHit"};
             ts.forEachResults(rs -> {
                 Integer libraryId = rs.getObject(FieldKey.fromString("libraryId/libraryId")) == null ? null : rs.getInt(FieldKey.fromString("libraryId/libraryId"));

--- a/tcrdb/src/org/labkey/tcrdb/pipeline/CellRangerVDJUtils.java
+++ b/tcrdb/src/org/labkey/tcrdb/pipeline/CellRangerVDJUtils.java
@@ -9,6 +9,8 @@ import org.labkey.api.assay.AssayProtocolSchema;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
+import org.labkey.api.collections.StringHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
@@ -125,8 +127,8 @@ public class CellRangerVDJUtils
         }
 
         File cDNAFile = CellHashingService.get().getCDNAInfoFile(outDir);
-        Map<String, CDNA_Library> htoNameToCDNAMap = new HashMap<>();
-        Map<Integer, CDNA_Library> cDNAMap = new HashMap<>();
+        Map<String, CDNA_Library> htoNameToCDNAMap = new StringHashMap<>();
+        Map<Integer, CDNA_Library> cDNAMap = new IntHashMap<>();
         if (cDNAFile.exists())
         {
             try (CSVReader reader = new CSVReader(Readers.getReader(cDNAFile), '\t'))
@@ -277,7 +279,7 @@ public class CellRangerVDJUtils
         }
 
         Map<String, AssayModel> rows = new HashMap<>();
-        Map<Integer, Set<String>> totalCellsBySample = new HashMap<>();
+        Map<Integer, Set<String>> totalCellsBySample = new IntHashMap<>();
         Set<String> uniqueContigNames = new HashSet<>();
         _log.info("processing clonotype CSV: " + allCsv.getPath());
 

--- a/tcrdb/src/org/labkey/tcrdb/pipeline/CellRangerVDJUtils.java
+++ b/tcrdb/src/org/labkey/tcrdb/pipeline/CellRangerVDJUtils.java
@@ -66,7 +66,7 @@ public class CellRangerVDJUtils
         _log = log;
     }
 
-    public void importAssayData(PipelineJob job, AnalysisModel model, File vLoupeFile, File outDir, Integer assayId, @Nullable Integer runId, boolean deleteExisting) throws PipelineJobException
+    public void importAssayData(PipelineJob job, AnalysisModel model, File vLoupeFile, File outDir, Integer assayId, @Nullable Long runId, boolean deleteExisting) throws PipelineJobException
     {
         File cellRangerOutDir = vLoupeFile.getParentFile();
 
@@ -617,7 +617,7 @@ public class CellRangerVDJUtils
         private String coalescedContigName;
     }
 
-    private Map<String, Object> processRow(AssayModel assayModel, AnalysisModel model, Map<Integer, CDNA_Library> cDNAMap, Integer runId, Map<Integer, Set<String>> totalCellsBySample, Map<String, String> sequenceMap) throws PipelineJobException
+    private Map<String, Object> processRow(AssayModel assayModel, AnalysisModel model, Map<Integer, CDNA_Library> cDNAMap, Long runId, Map<Integer, Set<String>> totalCellsBySample, Map<String, String> sequenceMap) throws PipelineJobException
     {
         CDNA_Library cDNARecord = cDNAMap.get(assayModel.cdna);
         if (cDNARecord == null)
@@ -665,7 +665,7 @@ public class CellRangerVDJUtils
         return "None".equals(input) ? null : StringUtils.trimToNull(input);
     }
 
-    private void saveRun(PipelineJob job, ExpProtocol protocol, AnalysisModel model, List<Map<String, Object>> rows, File outDir, Integer runId, boolean deleteExisting) throws PipelineJobException
+    private void saveRun(PipelineJob job, ExpProtocol protocol, AnalysisModel model, List<Map<String, Object>> rows, File outDir, Long runId, boolean deleteExisting) throws PipelineJobException
     {
         ViewBackgroundInfo info = job.getInfo();
         ViewContext vc = ViewContext.getMockViewContext(info.getUser(), info.getContainer(), info.getURL(), false);

--- a/tcrdb/src/org/labkey/tcrdb/pipeline/CellRangerVDJUtils.java
+++ b/tcrdb/src/org/labkey/tcrdb/pipeline/CellRangerVDJUtils.java
@@ -732,7 +732,7 @@ public class CellRangerVDJUtils
         }
     }
 
-    public static void deleteExistingData(AssayProvider ap, ExpProtocol protocol, Container c, User u, Logger log, int readsetId) throws PipelineJobException
+    public static void deleteExistingData(AssayProvider ap, ExpProtocol protocol, Container c, User u, Logger log, long readsetId) throws PipelineJobException
     {
         log.info("Preparing to delete any existing runs from this container for the same readset: " + readsetId);
 

--- a/tcrdb/src/org/labkey/tcrdb/pipeline/MiXCRAnalysis.java
+++ b/tcrdb/src/org/labkey/tcrdb/pipeline/MiXCRAnalysis.java
@@ -12,6 +12,7 @@ import org.json.JSONObject;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
@@ -290,11 +291,11 @@ public class MiXCRAnalysis extends AbstractPipelineStep implements AnalysisStep
         String version = new MiXCRWrapper(getPipelineCtx().getLogger()).getVersionString();
 
         //iterate selected species/loci:
-        Map<Integer, Map<String, Map<String, List<File>>>> tables = new HashMap<>();
+        Map<Integer, Map<String, Map<String, List<File>>>> tables = new IntHashMap<>();
         JSONArray libraries = getTcrDbs();
 
-        Map<Integer, Map<String, Map<String, Integer>>> totalReadsInExportedAlignments = new HashMap<>();
-        Map<Integer, Map<String, Map<String, Integer>>> totalReadsInExportedClones = new HashMap<>();
+        Map<Integer, Map<String, Map<String, Integer>>> totalReadsInExportedAlignments = new IntHashMap<>();
+        Map<Integer, Map<String, Map<String, Integer>>> totalReadsInExportedClones = new IntHashMap<>();
 
         for (JSONObject library : JsonUtil.toJSONObjectList(libraries))
         {

--- a/tcrdb/src/org/labkey/tcrdb/pipeline/MiXCRAnalysis.java
+++ b/tcrdb/src/org/labkey/tcrdb/pipeline/MiXCRAnalysis.java
@@ -1221,7 +1221,7 @@ public class MiXCRAnalysis extends AbstractPipelineStep implements AnalysisStep
 
     private void parseCloneOutput(Map<String, RunData> runMap, File table, AnalysisModel model, File inputBam) throws PipelineJobException
     {
-        Integer runId = SequencePipelineService.get().getExpRunIdForJob(getPipelineCtx().getJob());
+        Long runId = SequencePipelineService.get().getExpRunIdForJob(getPipelineCtx().getJob());
         ExpRun run = ExperimentService.get().getExpRun(runId);
 
         List<? extends ExpData> cloneDatas = run.getInputDatas(CLONES_FILE, ExpProtocol.ApplicationType.ExperimentRunOutput);
@@ -1328,7 +1328,7 @@ public class MiXCRAnalysis extends AbstractPipelineStep implements AnalysisStep
         }
     }
 
-    private Map<String, Object> getBaseRow(AnalysisModel model, Integer runId, TableInfo cDNATable) throws PipelineJobException
+    private Map<String, Object> getBaseRow(AnalysisModel model, Long runId, TableInfo cDNATable) throws PipelineJobException
     {
         Map<String, Object> row = new CaseInsensitiveHashMap<>();
         if (model.getReadset() != null)
@@ -1563,7 +1563,7 @@ public class MiXCRAnalysis extends AbstractPipelineStep implements AnalysisStep
         runProps.put("Name", "Analysis: " + model.getAnalysisId());
         runProps.put("analysisId", model.getAnalysisId());
 
-        Integer runId = SequencePipelineService.get().getExpRunIdForJob(getPipelineCtx().getJob());
+        Long runId = SequencePipelineService.get().getExpRunIdForJob(getPipelineCtx().getJob());
         runProps.put("pipelineRunId", runId);
 
         runProps.put("totalAlignments", rd.totalAlignments);


### PR DESCRIPTION
#### Rationale
Implement support for tables with BIGINT primary keys.  E.g. RowId/ObjectId BIGSERIAL
Because of the large number of shared classes, utilities, services, etc, a lot of code was migrated to used Long.  Code should now assume that an generic integer object key (as opposed to a known table PK), could be a Long.

This PR is aimed at a) Supporting ObjectID BIGSERIAL b) making it possible (but not automatic) to migrate tables that want to use RowId BIGSERIAL.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
New safer collection classes
  class Int/LongHashMap
  class Int/LongHashSet
explicit Class for key values in Map Objects returned by BaseSelector
  Selector.getValueMap(Class key)
safe "cast" using asInteger or asLong, as opposed to (Integer) and (Long)

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->
