### PR TITLE
Return Set<Class<?>> from Module "get test" methods

### DIFF
--- a/hivrc/src/org/labkey/hivrc/HivrcModule.java
+++ b/hivrc/src/org/labkey/hivrc/HivrcModule.java
@@ -4,10 +4,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.ldk.ExtendedSimpleModule;
-import org.labkey.api.module.Module;
-import org.labkey.api.module.ModuleContext;
-import org.labkey.api.query.DefaultSchema;
-import org.labkey.api.query.QuerySchema;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.BaseWebPartFactory;
 import org.labkey.api.view.HtmlView;
@@ -53,7 +49,7 @@ public class HivrcModule extends ExtendedSimpleModule
                 new BaseWebPartFactory("HIVRC Analysis Header")
                 {
                     @Override
-                    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+                    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
                     {
                         if (!portalCtx.getContainer().isWorkbook())
                         {

--- a/mGAP/src/org/labkey/mgap/mGAPModule.java
+++ b/mGAP/src/org/labkey/mgap/mGAPModule.java
@@ -208,7 +208,7 @@ public class mGAPModule extends ExtendedSimpleModule
     }
 
     @Override
-    public @NotNull Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return PageFlowUtil.set(mGapReleaseGenerator.TestCase.class);
     }

--- a/mGAP/src/org/labkey/mgap/mGapAuditTypeProvider.java
+++ b/mGAP/src/org/labkey/mgap/mGapAuditTypeProvider.java
@@ -29,13 +29,7 @@ public class mGapAuditTypeProvider extends AbstractAuditTypeProvider implements 
 
     public mGapAuditTypeProvider()
     {
-        
-    }
-
-    @Override
-    protected AbstractAuditDomainKind getDomainKind()
-    {
-        return new mGapAuditTypeProvider.AuditDomainKind();
+        super(new mGapAuditTypeProvider.AuditDomainKind());
     }
 
     @Override

--- a/primeseq/src/org/labkey/primeseq/PrimeseqModule.java
+++ b/primeseq/src/org/labkey/primeseq/PrimeseqModule.java
@@ -125,7 +125,7 @@ public class PrimeseqModule extends ExtendedSimpleModule
     }
 
     @Override
-    public @NotNull Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return PageFlowUtil.set(ClusterMaintenanceTask.TestCase.class);
     }


### PR DESCRIPTION
#### Rationale
Eliminate IntelliJ warnings caused by `Module` methods `getUnitTests()` and `getIntegrationTests()` returning raw `Set<Class>`; they now return `Set<Class<?>>`.

Also, eliminate use of the deprecated `AbstractAuditTypeProvider()` constructor and overrides of `getDomainKind()` in its subclasses; we now always call the constructor that passes in a `DomainKind`.