### PR TITLE
Continue adopting FileLike instead of File or Path

### DIFF
--- a/primeseq/src/org/labkey/primeseq/PrimeseqController.java
+++ b/primeseq/src/org/labkey/primeseq/PrimeseqController.java
@@ -556,7 +556,7 @@ public class PrimeseqController extends SpringActionController
                         json.put(prop, paramJson.get(prop));
                     }
 
-                    try (PrintWriter writer = PrintWriters.getPrintWriter(sj.getParametersFile()))
+                    try (PrintWriter writer = PrintWriters.getPrintWriter(sj.getParametersFile().openOutputStream()))
                     {
                         writer.write(json.toString(1));
                     }


### PR DESCRIPTION
#### Rationale
We can continue to strengthen our protections against path traversal attacks and start phasing out deprecated and overloaded methods that take or return Files or Paths.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7211

#### Changes
* Adjust to `FileLike`
