### PR TITLE
Migrate away from deprecated methods

### DIFF
--- a/elispot_assay/src/org/labkey/elispot_assay/assay/DefaultImportMethod.java
+++ b/elispot_assay/src/org/labkey/elispot_assay/assay/DefaultImportMethod.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.labkey.api.exp.api.ExperimentService.asInteger;
+import static org.labkey.api.util.IntegerUtils.asInteger;
 
 /**
  * Created with IntelliJ IDEA.

--- a/mGAP/src/org/labkey/mgap/mGAPController.java
+++ b/mGAP/src/org/labkey/mgap/mGAPController.java
@@ -122,7 +122,7 @@ import java.util.TreeSet;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import static org.labkey.api.exp.api.ExperimentService.asInteger;
+import static org.labkey.api.util.IntegerUtils.asInteger;
 
 
 public class mGAPController extends SpringActionController

--- a/mcc/src/org/labkey/mcc/query/TriggerHelper.java
+++ b/mcc/src/org/labkey/mcc/query/TriggerHelper.java
@@ -1,5 +1,7 @@
 package org.labkey.mcc.query;
 
+import jakarta.mail.Address;
+import jakarta.mail.Message;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,15 +32,12 @@ import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.settings.AppProps;
-import org.labkey.api.study.StudyService;
 import org.labkey.api.util.MailHelper;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.mcc.MccManager;
 import org.labkey.mcc.MccSchema;
 
-import jakarta.mail.Address;
-import jakarta.mail.Message;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -52,7 +51,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static org.labkey.api.exp.api.ExperimentService.asInteger;
+import static org.labkey.api.util.IntegerUtils.asInteger;
 
 /**
  * Created by bimber


### PR DESCRIPTION
#### Rationale
Prefer `IntegerUtils` methods