### PR TITLE
Remove `SqlserverOnlyTest` marker interface from tests

### DIFF
--- a/PMR/test/src/org/labkey/test/tests/pmr/PMRTest.java
+++ b/PMR/test/src/org/labkey/test/tests/pmr/PMRTest.java
@@ -36,7 +36,6 @@ import org.labkey.test.categories.LabModule;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.RReportHelper;
 import org.labkey.test.util.RemoteConnectionHelper;
-import org.labkey.test.util.SqlserverOnlyTest;
 import org.labkey.test.util.di.DataIntegrationHelper;
 import org.labkey.test.util.ehr.EHRClientAPIHelper;
 
@@ -50,7 +49,7 @@ import java.util.Map;
 import java.util.Set;
 
 @Category({External.class, LabModule.class})
-public class PMRTest extends BaseWebDriverTest implements SqlserverOnlyTest
+public class PMRTest extends BaseWebDriverTest
 {
     private final DataIntegrationHelper _etlHelper = new DataIntegrationHelper(getProjectName());
 


### PR DESCRIPTION
#### Rationale
The PMR module seems to have always supported Postgres. The test was flagged as SQL Server only, presumably because it wasn't actually deployed to any postgres servers.
The `SqlserverOnlyTest` marker interface will soon be unnecessary and should be removed from tests.

#### Changes
* Remove `SqlserverOnlyTest` marker interface from tests